### PR TITLE
Feature_2024.10.13.17.55_フローマトリクス表で担当者のメンバーに対応するところのみflow stepが表示されるように実装する_#8

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4,6 +4,12 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "@fortawesome/free-solid-svg-icons": "^6.6.0",
+                "@fortawesome/react-fontawesome": "^0.2.2",
+                "@reduxjs/toolkit": "^2.2.8",
+                "react-redux": "^9.1.2"
+            },
             "devDependencies": {
                 "@headlessui/react": "^2.0.0",
                 "@inertiajs/react": "^1.0.0",
@@ -747,6 +753,49 @@
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
             "dev": true
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+            "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
+            "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+            "peer": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.6.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
+            "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.6.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/react-fontawesome": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+            "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+            "dependencies": {
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+                "react": ">=16.3"
+            }
+        },
         "node_modules/@headlessui/react": {
             "version": "2.1.10",
             "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.10.tgz",
@@ -982,6 +1031,29 @@
             "dev": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.8.tgz",
+            "integrity": "sha512-eK/ieXftPRQfaBSmzsamXEyDwkntMTY0e9SG5ETsEOv5JIPKhu3mj992t6B8FJjlnSrZBAAqdT8oMkPe4j+P9g==",
+            "dependencies": {
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1286,6 +1358,11 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.3.2",
@@ -2087,6 +2164,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+            "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2186,8 +2272,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/jsesc": {
             "version": "3.0.2",
@@ -2257,7 +2342,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -2419,7 +2503,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2679,6 +2762,16 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2724,7 +2817,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -2743,6 +2835,33 @@
             },
             "peerDependencies": {
                 "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-redux": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+            "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.3",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25",
+                "react": "^18.0",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-refresh": {
@@ -2774,6 +2893,24 @@
             "engines": {
                 "node": ">=8.10.0"
             }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "peerDependencies": {
+                "redux": "^5.0.0"
+            }
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
         },
         "node_modules/resolve": {
             "version": "1.22.8",
@@ -3222,6 +3359,14 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+            "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/util-deprecate": {

--- a/src/package.json
+++ b/src/package.json
@@ -18,5 +18,11 @@
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.2.1",
         "vite": "^5.4.8"
+    },
+    "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@reduxjs/toolkit": "^2.2.8",
+        "react-redux": "^9.1.2"
     }
 }

--- a/src/resources/css/Flowstep.css
+++ b/src/resources/css/Flowstep.css
@@ -1,0 +1,21 @@
+/* Flowstep.css */
+
+.flow-step {
+  background-color: #f0f8ff; /* Light blue background */
+  border: 1px solid #ccc; /* Light gray border */
+  border-radius: 8px; /* Rounded corners */
+  padding: 10px; /* Padding around the text */
+  margin: 5px; /* Margin between flow steps */
+  transition: background-color 0.3s ease; /* Smooth transition for hover effect */
+}
+
+.flow-step:hover {
+  background-color: #e0f7fa; /* Slightly darker blue on hover */
+}
+
+.flow-step-name {
+  color: #333; /* Darker text color */
+  font-size: 1.2em; /* Larger font size */
+  text-align: center; /* Center the text */
+  margin: 0; /* Remove default margin */
+}

--- a/src/resources/css/MatrixView.css
+++ b/src/resources/css/MatrixView.css
@@ -1,5 +1,3 @@
-/* MatrixView.css */
-
 .matrix-table {
   width: 100%;
   border-collapse: collapse;
@@ -8,7 +6,22 @@
 .matrix-header {
   background-color: #f2f2f2;
   padding: 10px;
-  text-align: left;
+  text-align: center;
+  border: 1px solid #ddd;
+}
+
+.matrix-corner-header {
+  background-color: #f2f2f2;
+  padding: 10px;
+  text-align: center;
+  border: 1px solid #ddd;
+  width: 100px;
+}
+
+.matrix-side-header {
+  background-color: #f2f2f2;
+  padding: 10px;
+  text-align: center;
   border: 1px solid #ddd;
 }
 
@@ -17,10 +30,20 @@
   border: 1px solid #ddd;
 }
 
-/* メンバーのセルに色を塗る */
 .member-cell {
   background-color: #f2f2f2;
-  font-weight: bold;
+  display: flex;                     /* Use flexbox for layout */
+  justify-content: space-between;    /* Space between items: name on left, icon on right */
+  align-items: center;               /* Center items vertically */
+  padding: 10px;                     /* Add some padding for aesthetics */
+}
+
+.member-name {
+  flex-grow: 1;                      /* Allow the name to take up available space */
+}
+
+.member-icon {
+  margin-left: 8px;                 /* Optional: Add space between name and icon */
 }
 
 

--- a/src/resources/js/Components/AddFlowStepForm.jsx
+++ b/src/resources/js/Components/AddFlowStepForm.jsx
@@ -1,51 +1,105 @@
 import React, { useState } from 'react';
-import axios from 'axios';
 
-const AddFlowStepForm = ({ onFlowStepAdded }) => {
-    const [flowStepName, setFlowStepName] = useState('');
+const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
+    const [name, setName] = useState('');
     const [flowNumber, setFlowNumber] = useState('');
+    const [selectedMembers, setSelectedMembers] = useState([]);
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content'); // CSRFトークンを取得
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        
-        const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content'); // CSRFトークンの取得
+
+        // フォームの状態をデバッグ出力
+        console.log('Submitting Flow Step:');
+        console.log('Name:', name);
+        console.log('Flow Number:', flowNumber);
+        console.log('Selected Members:', selectedMembers);
+
+        // 送信するJSONデータをデバッグ出力
+        const jsonData = {
+            name: name,
+            flow_number: flowNumber,
+            member_id: selectedMembers, // 複数のメンバーIDを送信
+        };
+        console.log('JSON Data to be sent:', JSON.stringify(jsonData, null, 2)); // JSONをきれいに表示
 
         try {
-            const response = await axios.post('/api/flowsteps', {
-                name: flowStepName,
-                flow_number: flowNumber // flow_numberを送信
-            }, {
+            const response = await fetch('/api/flowsteps', {
+                method: 'POST',
                 headers: {
-                    'X-CSRF-TOKEN': token // CSRFトークンをヘッダーに追加
-                }
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                },
+                body: JSON.stringify(jsonData), // JSONデータを送信
             });
-            
-            if (onFlowStepAdded) {
-              setFlowStepName('');
-              setFlowNumber('');
-              onFlowStepAdded(); // フローステップが追加されたことを親コンポーネントに通知
+
+            // レスポンスのステータスをデバッグ出力
+            console.log('Response Status:', response.status);
+
+            if (!response.ok) {
+                const errorText = await response.text(); // テキストとしてエラーレスポンスを取得
+                throw new Error(`Error: ${response.status} ${errorText}`);
             }
+
+            const data = await response.json();
+            console.log('Response Data:', data); // レスポンスデータをデバッグ出力
+            onFlowStepAdded();
+            setName('');
+            setFlowNumber('');
+            setSelectedMembers([]);
         } catch (error) {
-            console.error('Failed to add flowstep', error);
+            console.error('Error submitting flowstep:', error.message);
         }
     };
 
+    const handleMemberChange = (e) => {
+        const options = e.target.options;
+        const value = [];
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected) {
+                value.push(options[i].value);
+            }
+        }
+        setSelectedMembers(value);
+        console.log('Selected Members Updated:', value); // 選択されたメンバーをデバッグ出力
+    };
+
     return (
-        <form onSubmit={handleSubmit} className="mb-4">
-            <input
-                type="text"
-                value={flowStepName}
-                onChange={(e) => setFlowStepName(e.target.value)}
-                placeholder="New Flow Step Name"
-                required
-            />
-            <input
-                type="text"
-                value={flowNumber}
-                onChange={(e) => setFlowNumber(e.target.value)}
-                placeholder="Flow Number"
-                required
-            />
+        <form onSubmit={handleSubmit}>
+            <div>
+                <label>Flow Step Name:</label>
+                <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    required
+                />
+            </div>
+            <div>
+                <label>Flow Step Number:</label>
+                <input
+                    type="number"
+                    value={flowNumber}
+                    onChange={(e) => setFlowNumber(e.target.value)}
+                    required
+                />
+            </div>
+            <div>
+                <label>Select Members:</label>
+                <select
+                    multiple // 複数選択を可能にする
+                    value={selectedMembers}
+                    onChange={handleMemberChange}
+                    required
+                >
+                    {members.map((member) => (
+                        <option key={member.id} value={member.id}>
+                            {member.name}
+                        </option>
+                    ))}
+                </select>
+            </div>
             <button type="submit">Add Flow Step</button>
         </form>
     );

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '../../css/Flowstep.css';
+
+const FlowStep = ({ name }) => {
+    return (
+        <div className="flow-step">
+            <h4 className="flow-step-name">{ name }</h4>
+        </div>
+    );
+};
+
+export default FlowStep;

--- a/src/resources/js/Components/FlowstepList.jsx
+++ b/src/resources/js/Components/FlowstepList.jsx
@@ -1,14 +1,19 @@
 import React, { useEffect, useState } from 'react';
+import FlowStep from './FlowStep'; // FlowStep コンポーネントをインポート
 
 const FlowstepList = ({ onFlowStepUpdated }) => {
     const [flowsteps, setFlowsteps] = useState([]);
 
     useEffect(() => {
         const fetchFlowsteps = async () => {
-            const response = await fetch('/api/flowsteps');
-            const data = await response.json();
-            setFlowsteps(data);
-            onFlowStepUpdated(); // フローステップが更新されたことを親コンポーネントに通知
+            try {
+                const response = await fetch('/api/flowsteps');
+                const data = await response.json();
+                setFlowsteps(data);
+                onFlowStepUpdated(); // フローステップが更新されたことを親コンポーネントに通知
+            } catch (error) {
+                console.error('Error fetching flowsteps:', error);
+            }
         };
 
         fetchFlowsteps();
@@ -16,9 +21,15 @@ const FlowstepList = ({ onFlowStepUpdated }) => {
 
     return (
         <ul>
-            {flowsteps.map((flowstep) => (
-                <li key={flowstep.id}>{flowstep.name}</li>
-            ))}
+            {flowsteps.length > 0 ? (
+                flowsteps.map((flowstep) => (
+                    <li key={flowstep.id}>
+                        <FlowStep name={flowstep.name} /> {/* FlowStep コンポーネントを使用 */}
+                    </li>
+                ))
+            ) : (
+                <li>No flow steps available.</li> // フローステップがない場合のメッセージ
+            )}
         </ul>
     );
 };

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,37 +1,57 @@
 import React from 'react';
-import '../../css/MatrixView.css'; // CSSファイルをインポート
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser } from '@fortawesome/free-solid-svg-icons'; // Import the specific icon
+import FlowStep from '../Components/Flowstep';
+import '../../css/MatrixView.css'; // Assuming you have this CSS import
 
 const MatrixView = ({ members, flowsteps }) => {
     return (
-        <table className="matrix-table">
-            <thead>
-                <tr>
-                    <th className="matrix-header">Members</th>
-                    {flowsteps.map((flowstep) => (
-                        <th key={flowstep.flow_number} className="matrix-header">
-                            {flowstep.flow_number}
-                        </th>
-                    ))}
-                </tr>
-            </thead>
-            <tbody>
-                {members.map((member) => (
-                    <tr key={member.id}>
-                        <td className="matrix-cell member-cell">{member.name}</td>
-                        {flowsteps.map((flowstep) => (
-                            <td key={flowstep.flow_number} className="matrix-cell">
-                                {/* flow-step要素を表示 */}
-                                <div className="flow-step">
-                                    {/* 必要な情報をここに格納 */}
-                                    <p>{flowstep.name}</p> {/* フローステップの名前 */}
-                                    {/* その他のフローステップに関連する要素 */}
-                                </div>
-                            </td>
+        <div>
+            <h2>Matrix View</h2>
+            {members.length === 0 || flowsteps.length === 0 ? (
+                <p>No data available.</p>
+            ) : (
+                <table className="matrix-table">
+                    <thead>
+                        <tr>
+                            <th className="matrix-corner-header">Members / FlowStep</th>
+                            {flowsteps.map((flowstep) => (
+                                <th key={flowstep.id} className="matrix-header">STEP {flowstep.flow_number}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {members.map((member) => (
+                            <tr key={member.id}>
+                                <td className="matrix-side-header">
+                                    <div className="member-cell">
+                                        <div>
+                                            {member.name}
+                                        </div>
+                                        <div  className="member-icon">
+                                            <FontAwesomeIcon icon={faUser} size="2x" /> {/* Correctly using the icon */}
+                                        </div>
+                                    </div>
+                                </td>
+                                {flowsteps.map((flowstep) => (
+                                    <td key={flowstep.id} className="matrix-cell">
+                                        {flowstep.members && flowstep.members.some(m => m.id === member.id) ? (
+                                            flowstep && flowstep.name ? (
+                                                <FlowStep name={flowstep.name} />
+                                            ) : (
+                                                <div></div>
+                                            )
+                                        ) : (
+                                            <div></div>
+                                        )}
+                                    </td>
+                                ))}
+                            </tr>
                         ))}
-                    </tr>
-                ))}
-            </tbody>
-        </table>
+                    </tbody>
+                </table>
+            )}
+        </div>
     );
 };
 

--- a/src/resources/js/Pages/Welcome.jsx
+++ b/src/resources/js/Pages/Welcome.jsx
@@ -5,7 +5,7 @@ import AddFlowStepForm from '../Components/AddFlowStepForm';
 import FlowstepList from '../Components/FlowstepList';
 import MatrixView from '../Components/MatrixView';
 
-const App = () => {
+const Welcome = () => {
     const [members, setMembers] = useState([]);
     const [flowsteps, setFlowsteps] = useState([]);
     const [membersUpdated, setMembersUpdated] = useState(false);
@@ -48,7 +48,7 @@ const App = () => {
             <MemberList key={membersUpdated} /> {/* ステート変更でリストをリフレッシュ */}
 
             <h1>Flowstep Management</h1>
-            <AddFlowStepForm onFlowStepAdded={handleFlowStepAdded} />
+            <AddFlowStepForm members={members} onFlowStepAdded={handleFlowStepAdded} />
             <FlowstepList onFlowStepUpdated={handleFlowStepAdded} /> {/* フローステップリストを表示 */}
 
             <h2>Matrix View</h2>
@@ -57,4 +57,4 @@ const App = () => {
     );
 };
 
-export default App;
+export default Welcome;


### PR DESCRIPTION
## GitHub Issue Ticket
- close #8 

## やった事
`このプルリクエストにて何をしたのか？`
 - 担当者として選択したMemberに対応する行にのみFlowstepコンポーネントが表示されるように実装 (#8)
   - MatrixViewコンポーネント上に表示する項目をFlowstepListコンポーネント → Flowstepコンポーネントへ変更 

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
フローマトリクス表にはFlowstep間の矢印や、FlowStepに関連するシステムへの矢印などを描画するため
担当していないFlowstepは表示しないことが望ましい

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
