### PR TITLE
Feature 2024.10.14.05.02 flow stepコンポーネントをdndで担当memberを更新可能にする #12

### DIFF
--- a/src/app/Http/Controllers/FlowstepMemberController.php
+++ b/src/app/Http/Controllers/FlowstepMemberController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\FlowstepMember; // 中間テーブルモデル
+use Illuminate\Http\Request;
+
+class FlowstepMemberController extends Controller
+{
+
+  public function store(Request $request)
+  {
+      try {
+          $request->validate([
+              'memberId' => 'required|exists:members,id',
+              'flowstepId' => 'required|exists:flowsteps,id',
+          ]);
+
+          // フローステップの割り当てを行う
+          FlowstepMember::updateOrCreate(
+              ['member_id' => $request->memberId, 'flowstep_id' => $request->flowstepId]
+          );
+
+          return response()->json(['message' => 'FlowStep assigned successfully']);
+      } catch (\Exception $e) {
+          \Log::error($e->getMessage()); // エラーログに記録
+          return response()->json(['error' => 'Failed to assign FlowStep'], 500);
+      }
+  }
+
+}

--- a/src/app/Models/FlowstepMember.php
+++ b/src/app/Models/FlowstepMember.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FlowstepMember extends Model
+{
+    use HasFactory;
+
+    protected $table = 'flowstep_member'; // テーブル名を指定
+
+    // マスアサインメントを許可するフィールド
+    protected $fillable = [
+        'member_id',    // ここに member_id を追加
+        'flowstep_id',  // 必要なフィールドも追加
+        // 他のフィールドも必要に応じて追加
+    ];
+}

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,59 +1,77 @@
+// MatrixView.jsx
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 import FlowStep from '../Components/Flowstep';
+import { DndProvider, useDrop } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
-const MatrixView = ({ members, flowsteps }) => {
-    console.log("Members:", members); // membersの内容を出力
-    console.log("Flowsteps:", flowsteps); // flowstepsの内容を出力
-
+const MatrixView = ({ members, flowsteps, onAssignFlowStep }) => {
     return (
-        <div>
-            <h2>Matrix View</h2>
-            {members.length === 0 || flowsteps.length === 0 ? (
-                <p>No data available.</p>
-            ) : (
-                <table className="matrix-table">
-                    <thead>
-                        <tr>
-                            <th className="matrix-corner-header">Members / FlowStep</th>
-                            {flowsteps.map((flowstep) => (
-                                <th key={flowstep.id} className="matrix-header">STEP {flowstep.flow_number}</th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {members.map((member) => (
-                            <tr key={member.id}>
-                                <td className="matrix-side-header">
-                                    <div className="member-cell">
-                                        <div>
-                                            {member.name}
-                                        </div>
-                                        <div className="member-icon">
-                                            <FontAwesomeIcon icon={faUser} size="2x" />
-                                        </div>
-                                    </div>
-                                </td>
-                                {flowsteps.map((flowstep) => {
-                                    console.log("Flowstep:", flowstep); // ここでflowstepを出力
-                                    return (
-                                        <td key={flowstep.id} className="matrix-cell">
-                                            {flowstep && flowstep.members && flowstep.members.some(m => m.id === member.id) ? (
-                                                <FlowStep flowstep={flowstep} />
-                                            ) : (
-                                                <div></div>
-                                            )}
-                                        </td>
-                                    );
-                                })}
+        <DndProvider backend={HTML5Backend}>
+            <div>
+                <h2>Matrix View</h2>
+                {members.length === 0 || flowsteps.length === 0 ? (
+                    <p>No data available.</p>
+                ) : (
+                    <table className="matrix-table">
+                        <thead>
+                            <tr>
+                                <th className="matrix-corner-header">Members / FlowStep</th>
+                                {flowsteps.map((flowstep) => (
+                                    <th key={flowstep.id} className="matrix-header">STEP {flowstep.flow_number}</th>
+                                ))}
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
-            )}
-        </div>
+                        </thead>
+                        <tbody>
+                            {members.map((member) => (
+                                <tr key={member.id}>
+                                    <td className="matrix-side-header">
+                                        <div className="member-cell">
+                                            <div>
+                                                {member.name}
+                                            </div>
+                                            <div className="member-icon">
+                                                <FontAwesomeIcon icon={faUser} size="2x" />
+                                            </div>
+                                        </div>
+                                    </td>
+                                    {flowsteps.map((flowstep) => {
+                                        // ドロップ処理をここで設定
+                                        const [{ isOver }, drop] = useDrop({
+                                            accept: 'FLOWSTEP',
+                                            drop: (item) => {
+                                                // メンバーIDを取得
+                                                onAssignFlowStep(member.id, item.id);
+                                            },
+                                            collect: (monitor) => ({
+                                                isOver: monitor.isOver(),
+                                            }),
+                                        });
+
+                                        return (
+                                            <td 
+                                                key={flowstep.id} 
+                                                className="matrix-cell" 
+                                                ref={drop}
+                                                style={{ backgroundColor: isOver ? '#f0f0f0' : 'white' }} // ドロップエリアの色を変更
+                                            >
+                                                {flowstep.members && flowstep.members.some(m => m.id === member.id) ? (
+                                                    <FlowStep flowstep={flowstep} />
+                                                ) : (
+                                                    <div></div>
+                                                )}
+                                            </td>
+                                        );
+                                    })}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </DndProvider>
     );
 };
 

--- a/src/resources/js/Pages/Welcome.jsx
+++ b/src/resources/js/Pages/Welcome.jsx
@@ -21,6 +21,30 @@ const Welcome = () => {
         setFlowstepsUpdated(!flowstepsUpdated); // ステートをトグルしてリストを再レンダリング
     };
 
+    // FlowStepをメンバーに割り当てる関数を追加
+    const handleAssignFlowStep = async (memberId, flowstepId) => {
+        const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+        try {
+            const response = await fetch('/api/assign-flowstep', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': token, // CSRFトークンをヘッダーに追加
+                },
+                body: JSON.stringify({ memberId, flowstepId }),
+            });
+
+            if (response.ok) {
+                console.log(`Assigned FlowStep ${flowstepId} to Member ${memberId}`);
+                // ここで必要に応じてメンバーやフローステップの状態を更新することができます
+            } else {
+                console.error("Failed to assign FlowStep");
+            }
+        } catch (error) {
+            console.error("Error assigning FlowStep:", error);
+        }
+    };
+
     useEffect(() => {
         const fetchMembers = async () => {
             const response = await fetch('/api/members');
@@ -52,7 +76,7 @@ const Welcome = () => {
             <FlowstepList onFlowStepUpdated={handleFlowStepAdded} /> {/* フローステップリストを表示 */}
 
             <h2>Matrix View</h2>
-            <MatrixView members={members} flowsteps={flowsteps} />
+            <MatrixView members={members} flowsteps={flowsteps} onAssignFlowStep={handleAssignFlowStep} />
         </div>
     );
 };

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -34,3 +34,6 @@ Route::post('/api/members', [MemberController::class, 'store']);
 use App\Http\Controllers\FlowstepController;
 Route::get('/api/flowsteps', [FlowstepController::class, 'index']);
 Route::post('/api/flowsteps', [FlowstepController::class, 'store']);
+
+use App\Http\Controllers\FlowstepMemberController;
+Route::post('/api/assign-flowstep', [FlowstepMemberController::class, 'store']);


### PR DESCRIPTION
## GitHub Issue Ticket
- close #12 

## やった事
`このプルリクエストにて何をしたのか？`
FlowStepコンポーネントをDnDすることにより担当者を更新することができるように実装
（担当者変更ではなく、担当者を変更したFlowStepコンポーネントを複製する機能にとどまっている。要変更）

https://github.com/user-attachments/assets/b9300da0-b33a-4363-85f9-91e44f8c24f8


### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
フロー図の変更で担当者を変えたい場面に対応する機能を実装するため。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## 要改善点
 - [ ] リロードしないとDnDによって作成されたFlowStepコンポーネントが表示されない
   - （※Laravelデータベースにはリロードしなくても反映されている）
 - [ ] 担当者が違うFlowStepコンポーネントの「複製」をFlowStepコンポーネントの担当者の「変更」にしたい

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
