### PR TITLE
Feature_2024.10.54.10.14_Flowstepコンポーネントのdnd前後のmemberのidを取得できるように実装する_#14

### DIFF
--- a/src/app/Http/Controllers/FlowstepMemberController.php
+++ b/src/app/Http/Controllers/FlowstepMemberController.php
@@ -14,9 +14,18 @@ class FlowstepMemberController extends Controller
           $request->validate([
               'memberId' => 'required|exists:members,id',
               'flowstepId' => 'required|exists:flowsteps,id',
+              'assignedMembersBeforeDrop' => 'array', // ドロップ前のメンバーのリストを検証
+              'assignedMembersBeforeDrop.*' => 'exists:members,id', // 各IDが有効であることを検証
           ]);
 
-          // フローステップの割り当てを行う
+          // ドロップ前のメンバー関連を削除する
+          if ($request->has('assignedMembersBeforeDrop')) {
+              FlowstepMember::where('flowstep_id', $request->flowstepId)
+                  ->whereIn('member_id', $request->assignedMembersBeforeDrop)
+                  ->delete();
+          }
+
+          // 新しいメンバー関連付けを作成または更新
           FlowstepMember::updateOrCreate(
               ['member_id' => $request->memberId, 'flowstep_id' => $request->flowstepId]
           );

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -7,6 +7,7 @@ import { DndProvider, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
+// MatrixView.jsx
 const MatrixView = ({ members, flowsteps, onAssignFlowStep }) => {
     return (
         <DndProvider backend={HTML5Backend}>
@@ -38,12 +39,19 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep }) => {
                                         </div>
                                     </td>
                                     {flowsteps.map((flowstep) => {
-                                        // ドロップ処理をここで設定
+                                        // 事前に関連するメンバーIDを取得
+                                        const assignedMembersBeforeDrop = flowstep.members ? flowstep.members.map(m => m.id) : [];
+
+                                        // ドロップ処理を設定
                                         const [{ isOver }, drop] = useDrop({
                                             accept: 'FLOWSTEP',
                                             drop: (item) => {
                                                 // メンバーIDを取得
-                                                onAssignFlowStep(member.id, item.id);
+                                                onAssignFlowStep(
+                                                    member.id, 
+                                                    item.id, 
+                                                    assignedMembersBeforeDrop // ドロップ前の関連メンバーIDを渡す
+                                                );
                                             },
                                             collect: (monitor) => ({
                                                 isOver: monitor.isOver(),

--- a/src/resources/js/Pages/Welcome.jsx
+++ b/src/resources/js/Pages/Welcome.jsx
@@ -22,19 +22,26 @@ const Welcome = () => {
     };
 
     // FlowStepをメンバーに割り当てる関数を追加
-    const handleAssignFlowStep = async (memberId, flowstepId) => {
+    const handleAssignFlowStep = async (memberId, flowstepId, assignedMembersBeforeDrop) => {
         const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+        
         try {
+            // サーバーに送信するデータにドロップ前のメンバー情報を追加
             const response = await fetch('/api/assign-flowstep', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-CSRF-TOKEN': token, // CSRFトークンをヘッダーに追加
                 },
-                body: JSON.stringify({ memberId, flowstepId }),
+                body: JSON.stringify({
+                    memberId,
+                    flowstepId,
+                    assignedMembersBeforeDrop, // ドロップ前のメンバーIDをサーバーに送信
+                }),
             });
-
+    
             if (response.ok) {
+                console.log(`Member Id from ${assignedMembersBeforeDrop} to ${memberId}`);
                 console.log(`Assigned FlowStep ${flowstepId} to Member ${memberId}`);
                 // ここで必要に応じてメンバーやフローステップの状態を更新することができます
             } else {
@@ -44,7 +51,7 @@ const Welcome = () => {
             console.error("Error assigning FlowStep:", error);
         }
     };
-
+    
     useEffect(() => {
         const fetchMembers = async () => {
             const response = await fetch('/api/members');


### PR DESCRIPTION
## GitHub Issue Ticket
- close #14 

## やった事
`このプルリクエストにて何をしたのか？`
 - DnD前後に担当者Memberのidを取得するように実装
   - DnD前：memberId
   - DnD後：assignedMembersBeforeDrop

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
中間テーブルのFlowstepMemberモデルにおける担当者Memberのidの付け替えのロジックを
わかりやすく記述するため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
