### PR TITLE
Feature_2024.10.14.11.09_FlowstepコンポーネントのDnDによるmemberのidの更新をリロードせず処理されるようにしたい_#16

### DIFF
--- a/src/resources/js/Components/FlashMessage.jsx
+++ b/src/resources/js/Components/FlashMessage.jsx
@@ -1,0 +1,11 @@
+const FlashMessage = ({ message }) => {
+  if (!message) return null;
+
+  return (
+      <div style={{ backgroundColor: '#dff0d8', color: '#3c763d', padding: '10px', borderRadius: '5px', marginBottom: '10px' }}>
+          {message}
+      </div>
+  );
+};
+
+export default FlashMessage;

--- a/src/resources/js/Pages/Welcome.jsx
+++ b/src/resources/js/Pages/Welcome.jsx
@@ -26,7 +26,6 @@ const Welcome = () => {
         const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
         
         try {
-            // サーバーに送信するデータにドロップ前のメンバー情報を追加
             const response = await fetch('/api/assign-flowstep', {
                 method: 'POST',
                 headers: {
@@ -41,9 +40,12 @@ const Welcome = () => {
             });
     
             if (response.ok) {
-                console.log(`Member Id from ${assignedMembersBeforeDrop} to ${memberId}`);
                 console.log(`Assigned FlowStep ${flowstepId} to Member ${memberId}`);
-                // ここで必要に応じてメンバーやフローステップの状態を更新することができます
+                
+                // メンバーまたはフローステップに変更があったことを通知
+                setMembersUpdated(!membersUpdated);
+                setFlowstepsUpdated(!flowstepsUpdated);
+    
             } else {
                 console.error("Failed to assign FlowStep");
             }
@@ -51,7 +53,7 @@ const Welcome = () => {
             console.error("Error assigning FlowStep:", error);
         }
     };
-    
+        
     useEffect(() => {
         const fetchMembers = async () => {
             const response = await fetch('/api/members');


### PR DESCRIPTION
## GitHub Issue Ticket
- close #16 

## やった事
`このプルリクエストにて何をしたのか？`
 - MatrixView上のFlowStepコンポーネントDnDによる担当者Memberの変更をリロードせず行えるようにした
 - MatrixView上のFlowStepコンポーネントDnDによる担当者Memberの変更ができた時のフラッシュメッセージを追加

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
担当者Memberが変更されたかどうかをリロードをして確認しなければならない煩わしさを解消

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
