### PR TITLE
Debug_2024.10.14.22.06_DnDによる担当者Member更新機能とMatrixView上のAddMemberFormの機能の両立

### DIFF
--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,27 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 import FlowStep from '../Components/Flowstep';
+import AddMemberForm from '../Components/AddMemberForm';
 import { DndProvider, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
-import AddMemberForm from '../Components/AddMemberForm';
 
 const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded }) => {
-    // 先にフックを呼び出す
-    const dropRefs = flowsteps.map(() => useDrop({
-        accept: 'FLOWSTEP',
-        drop: (item, monitor, index) => {
-            const assignedMembersBeforeDrop = flowsteps[index].members 
-                ? flowsteps[index].members.map(m => m.id) 
-                : [];
-            onAssignFlowStep(members[index].id, item.id, assignedMembersBeforeDrop);
-        },
-        collect: (monitor) => ({
-            isOver: monitor.isOver(),
-        }),
-    }));
-
     return (
         <DndProvider backend={HTML5Backend}>
             <div>
@@ -39,37 +25,13 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded }) => 
                             </tr>
                         </thead>
                         <tbody>
-                            {members.map((member, memberIndex) => (
-                                <tr key={member.id}>
-                                    <td className="matrix-side-header">
-                                        <div className="member-cell">
-                                            <div>
-                                                {member.name}
-                                            </div>
-                                            <div className="member-icon">
-                                                <FontAwesomeIcon icon={faUser} size="2x" />
-                                            </div>
-                                        </div>
-                                    </td>
-                                    {flowsteps.map((flowstep, flowstepIndex) => {
-                                        const [{ isOver }, drop] = dropRefs[flowstepIndex];
-
-                                        return (
-                                            <td 
-                                                key={flowstep.id} 
-                                                className="matrix-cell" 
-                                                ref={drop}
-                                                style={{ backgroundColor: isOver ? '#f0f0f0' : 'white' }}
-                                            >
-                                                {flowstep.members && flowstep.members.some(m => m.id === member.id) ? (
-                                                    <FlowStep flowstep={flowstep} />
-                                                ) : (
-                                                    <div></div>
-                                                )}
-                                            </td>
-                                        );
-                                    })}
-                                </tr>
+                            {members.map((member) => (
+                                <MemberRow 
+                                    key={member.id} 
+                                    member={member} 
+                                    flowsteps={flowsteps} 
+                                    onAssignFlowStep={onAssignFlowStep} 
+                                />
                             ))}
                             <tr>
                                 <td className="matrix-side-header">
@@ -88,6 +50,49 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded }) => 
                 )}
             </div>
         </DndProvider>
+    );
+};
+
+const MemberRow = ({ member, flowsteps, onAssignFlowStep }) => {
+    return (
+        <tr>
+            <td className="matrix-side-header">
+                <div className="member-cell">
+                    <div>{member.name}</div>
+                    <div className="member-icon">
+                        <FontAwesomeIcon icon={faUser} size="2x" />
+                    </div>
+                </div>
+            </td>
+            {flowsteps.map((flowstep) => {
+                const assignedMembersBeforeDrop = flowstep.members ? flowstep.members.map(m => m.id) : [];
+
+                const [{ isOver }, drop] = useDrop({
+                    accept: 'FLOWSTEP',
+                    drop: (item) => {
+                        onAssignFlowStep(member.id, item.id, assignedMembersBeforeDrop);
+                    },
+                    collect: (monitor) => ({
+                        isOver: monitor.isOver(),
+                    }),
+                });
+
+                return (
+                    <td 
+                        key={flowstep.id} 
+                        className="matrix-cell" 
+                        ref={drop}
+                        style={{ backgroundColor: isOver ? '#f0f0f0' : 'white' }}
+                    >
+                        {flowstep.members && flowstep.members.some(m => m.id === member.id) ? (
+                            <FlowStep flowstep={flowstep} />
+                        ) : (
+                            <div></div>
+                        )}
+                    </td>
+                );
+            })}
+        </tr>
     );
 };
 


### PR DESCRIPTION
## GitHub Issue Ticket
- close #21 

## やった事
`このプルリクエストにて何をしたのか？`
下記機能の両立
 - MatrixView上のFlowStepコンポーネントDnDによる担当者Memberの更新
   - https://github.com/maixhashi/matrixflow/pull/17
 - MatrixView上の最下行へAddMemberFormを実装
   - https://github.com/maixhashi/matrixflow/pull/20

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Pull Requestでマージ済の独立したマトリクスの基本機能を両立化


## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
 - エラー対応
   - エラー内容  `Rendered more hooks than during the previous render.`
     - 前回のレンダリングと異なる数のフックが呼び出されるときに発生
     - useDropフックを条件付きで呼び出すことが原因
       - flowsteps.mapの中でuseDropを呼び出している
       - flowstepsの配列が変更されるたびに、フックの呼び出し回数が変わることになる。
       - 特に、AddMemberFormを使って新しいメンバーを追加すると、membersの長さが変わり、flowstepsも変わる可能性があるため、エラーが発生する。
    - 解決策
      - フックの呼び出しを一貫性のある場所に置く
        - useDropをflowsteps.mapの外に移動し
        - 別のコンポーネントとしてドロップエリアを作成する
          - MatrixRowコンポーネントとして別管理
          -  → フックの数が変わらないようにする