### PR TITLE
Feature 2024.10.15.05.59 マトリクス最終列をflow stepを追加できることがわかるようにスタイリングする #23

### DIFF
--- a/src/resources/css/AddFlowStepForm.css
+++ b/src/resources/css/AddFlowStepForm.css
@@ -1,0 +1,37 @@
+.form-container {
+  background-color: #f9f9f9;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  margin: 10px 0;
+}
+
+.form-container label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+
+.form-container input[type="text"],
+.form-container input[type="number"],
+.form-container select {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 15px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.form-container button {
+  background-color: #4CAF50;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.form-container button:hover {
+  background-color: #45a049;
+}

--- a/src/resources/css/MatrixView.css
+++ b/src/resources/css/MatrixView.css
@@ -58,3 +58,9 @@
 .matrix-cell:hover .flow-step {
   background-color: #d1e7ff; /* ホバー時のフローステップの背景色 */
 }
+
+.next-step-column {
+  background-color: #BBBBBB; /* 薄い灰色 */
+  font-weight: bold; /* 強調するために太字にする */
+  border: 2px dotted #DDDDDD; /* 黒の点線枠線 */
+}

--- a/src/resources/css/ModalforAddFlowStepForm.css
+++ b/src/resources/css/ModalforAddFlowStepForm.css
@@ -1,0 +1,31 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000; /* 他の要素の上に表示する */
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}

--- a/src/resources/js/Components/AddFlowStepForm.jsx
+++ b/src/resources/js/Components/AddFlowStepForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
+import '../../css/AddFlowStepForm.css';  // スタイルをインポート
 
-const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
+const AddFlowStepForm = ({ members = [], onFlowStepAdded }) => {
     const [name, setName] = useState('');
     const [flowNumber, setFlowNumber] = useState('');
     const [selectedMembers, setSelectedMembers] = useState([]);
@@ -10,13 +11,11 @@ const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
     const handleSubmit = async (e) => {
         e.preventDefault();
 
-        // フォームの状態をデバッグ出力
         console.log('Submitting Flow Step:');
         console.log('Name:', name);
         console.log('Flow Number:', flowNumber);
         console.log('Selected Members:', selectedMembers);
 
-        // 送信するJSONデータをデバッグ出力
         const jsonData = {
             name: name,
             flow_number: flowNumber,
@@ -34,7 +33,6 @@ const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
                 body: JSON.stringify(jsonData), // JSONデータを送信
             });
 
-            // レスポンスのステータスをデバッグ出力
             console.log('Response Status:', response.status);
 
             if (!response.ok) {
@@ -66,7 +64,7 @@ const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
     };
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form className="form-container" onSubmit={handleSubmit}>
             <div>
                 <label>Flow Step Name:</label>
                 <input
@@ -82,7 +80,6 @@ const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
                     type="number"
                     value={flowNumber}
                     onChange={(e) => setFlowNumber(e.target.value)}
-                    required
                 />
             </div>
             <div>
@@ -93,11 +90,15 @@ const AddFlowStepForm = ({ members, onFlowStepAdded }) => {
                     onChange={handleMemberChange}
                     required
                 >
-                    {members.map((member) => (
-                        <option key={member.id} value={member.id}>
-                            {member.name}
-                        </option>
-                    ))}
+                    {members.length > 0 ? (
+                        members.map((member) => (
+                            <option key={member.id} value={member.id}>
+                                {member.name}
+                            </option>
+                        ))
+                    ) : (
+                        <option disabled>No members available</option>
+                    )}
                 </select>
             </div>
             <button type="submit">Add Flow Step</button>

--- a/src/resources/js/Components/ModalforAddFlowStepForm.jsx
+++ b/src/resources/js/Components/ModalforAddFlowStepForm.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import '../../css/ModalforAddFlowStepForm.css';
+
+const ModalforAddFlowStepForm = ({ isOpen, onClose, children }) => {
+    if (!isOpen) return null; // モーダルが開いていない場合は何も表示しない
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={onClose}>×</button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default ModalforAddFlowStepForm;


### PR DESCRIPTION
## GitHub Issue Ticket
- close #23 

## やった事
`このプルリクエストにて何をしたのか？`
 - ModalforAddFlowStepFormコンポーネント（新規実装）
   - AddFlowStepFormコンポーネントを含むモーダル
 - MatrixViewコンポーネント
   - FlowStepが1つもない列
     - 最終列として追加余地があることがわかるようにスタイルを変更
   - FlowStepが1つ以上ある列 
     - FlowStepがない列についてはModalforAddFlowStepFormを開くアイコンを表示する 

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
最終行にAddMemberFormを載せたのと同様、ユーザーに追加できることがわかるように示すため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
