### PR TITLE
Feature 2024.10.16.22.15 dn dによるmatrix viewの行入れ替え機能を実装する #35

### DIFF
--- a/src/app/Http/Controllers/MemberController.php
+++ b/src/app/Http/Controllers/MemberController.php
@@ -11,7 +11,7 @@ class MemberController extends Controller
     public function index()
     {
         // メンバー情報をすべて取得
-        $members = Member::all();
+        $members = Member::orderBy('order_on_matrix')->get();
 
         // JSON形式で返す（Unicodeエスケープを無効にする）
         return response()->json($members, 200, [], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
@@ -30,5 +30,27 @@ class MemberController extends Controller
         $member->save();
 
         return response()->json(['message' => 'Member created successfully!', 'member' => $member], 201);
-    }       
+    }
+    
+    public function saveOrder(Request $request)
+    {
+        // リクエストボディから member_ids を取得
+        $memberIds = $request->input('member_ids');
+    
+        // デバッグ用: リクエストの内容を表示
+        \Log::info('Received member_ids:', ['member_ids' => $memberIds]); // 修正
+    
+        // memberIds が null または配列でない場合にエラーメッセージを返す
+        if (!$memberIds || !is_array($memberIds)) {
+            return response()->json(['error' => 'Invalid data provided'], 400);
+        }
+    
+        foreach ($memberIds as $order => $id) {
+            // 各メンバーの order_on_matrix カラムを更新
+            Member::where('id', $id)->update(['order_on_matrix' => $order]);
+        }
+    
+        return response()->json(['success' => true]);
+    }
+                
 }

--- a/src/database/migrations/2024_10_16_134523_add_order_on_matrix_to_members_table.php
+++ b/src/database/migrations/2024_10_16_134523_add_order_on_matrix_to_members_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderOnMatrixToMembersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->integer('order_on_matrix')->nullable()->after('name'); // 名前の後に追加
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            if (Schema::hasColumn('members', 'order_on_matrix')) {
+                $table->dropColumn('order_on_matrix');
+            }
+        });
+    }
+
+}

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -5,7 +5,7 @@ import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
 import AddFlowStepForm from '../Components/AddFlowStepForm';
-import { DndProvider, useDrop } from 'react-dnd';
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
@@ -47,9 +47,27 @@ const MatrixCol = ({ flowsteps, members, openModal, flowNumber, onAssignFlowStep
     );
 };
 
-const MatrixRow = ({ member, flowsteps, onAssignFlowStep, openModal, maxFlowNumber }) => {
+const MatrixRow = ({ member, flowsteps, onAssignFlowStep, openModal, maxFlowNumber, index, moveRow }) => {
+    const [{ isDragging }, drag] = useDrag(() => ({
+        type: 'ROW',
+        item: { index },
+        collect: (monitor) => ({
+            isDragging: monitor.isDragging(),
+        }),
+    }), [index]);
+
+    const [, drop] = useDrop(() => ({
+        accept: 'ROW',
+        hover: (item) => {
+            if (item.index !== index) {
+                moveRow(item.index, index);
+                item.index = index; // Update the index to reflect the new position
+            }
+        },
+    }), [index, moveRow]);
+
     return (
-        <tr>
+        <tr ref={(node) => drag(drop(node))} style={{ opacity: isDragging ? 0.5 : 1 }}>
             <td className="matrix-side-header">
                 <div className="member-cell">
                     <div>{member.name}</div>
@@ -84,15 +102,19 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded, onFlo
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedMember, setSelectedMember] = useState(null);
     const [selectedStepNumber, setSelectedStepNumber] = useState(null);
-    const [maxFlowNumber, setMaxFlowNumber] = useState(0);  // 初期値を1に設定
+    const [maxFlowNumber, setMaxFlowNumber] = useState(0);
+    const [memberList, setMemberList] = useState(members); // For reordering members
+
+    useEffect(() => {
+        setMemberList(members);
+    }, [members]);
 
     useEffect(() => {
         if (flowsteps.length > 0) {
-            // flowstepsの最大のflow_numberを取得。最低でも1に設定
             const maxFlowNumber = Math.max(0, ...flowsteps.map(step => step.flow_number));
             setMaxFlowNumber(maxFlowNumber);
         } else {
-            setMaxFlowNumber(0);  // flowstepsがない場合も1に設定
+            setMaxFlowNumber(0);
         }
     }, [flowsteps]);
 
@@ -108,18 +130,24 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded, onFlo
         setIsModalOpen(false);
     };
 
+    const moveRow = (fromIndex, toIndex) => {
+        const updatedMembers = [...memberList];
+        const [movedMember] = updatedMembers.splice(fromIndex, 1);
+        updatedMembers.splice(toIndex, 0, movedMember);
+        setMemberList(updatedMembers);
+    };
+
     return (
         <DndProvider backend={HTML5Backend}>
             <div className="matrix-container">
                 <h2>Matrix View</h2>
-                {members.length === 0 && flowsteps.length === 0 ? (
+                {memberList.length === 0 && flowsteps.length === 0 ? (
                     <p>No data available.</p>
                 ) : (
                     <table className="matrix-table">
                         <thead>
                             <tr>
                                 <th className="matrix-corner-header">Members / FlowStep</th>
-                                {/* 初期ステップの設定を1からにする */}
                                 {Array.from({ length: maxFlowNumber }, (_, i) => i + 1).map((flowNumber) => (
                                     <th key={flowNumber} className="matrix-header">STEP {flowNumber}</th>
                                 ))}
@@ -127,7 +155,7 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded, onFlo
                             </tr>
                         </thead>
                         <tbody>
-                            {members.map((member) => (
+                            {memberList.map((member, index) => (
                                 <MatrixRow
                                     key={member.id}
                                     member={member}
@@ -135,6 +163,8 @@ const MatrixView = ({ members, flowsteps, onAssignFlowStep, onMemberAdded, onFlo
                                     onAssignFlowStep={onAssignFlowStep}
                                     openModal={openModal}
                                     maxFlowNumber={maxFlowNumber}
+                                    index={index} // Pass the index to MatrixRow
+                                    moveRow={moveRow} // Pass moveRow function to MatrixRow
                                 />
                             ))}
                             <tr>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -30,6 +30,8 @@ use App\Http\Controllers\MemberController;
 
 Route::get('/api/members', [MemberController::class, 'index']);
 Route::post('/api/members', [MemberController::class, 'store']);
+Route::post('/api/save-order', [MemberController::class, 'saveOrder']);
+
 
 use App\Http\Controllers\FlowstepController;
 Route::get('/api/flowsteps', [FlowstepController::class, 'index']);


### PR DESCRIPTION
## GitHub Issue Ticket
- close #35

## やった事
`このプルリクエストにて何をしたのか？`
 - MatrixRowにDnDを実装
 - 行の順序をLaravelデータベースに保存する機能を実装
   - Laravel
     - order_on_matrix カラムを追加 
     - Laravel api を作成 `/api/save-order`
     - MemberCotrollerにsaveOrderを実装
   - React
     -  saveOrderToServerで行の順序を入れ替え

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
「マトリックスの上に行くほど役職が上」などを表したい際に、Memberの行順序を入れ替える機能がある方が
望ましいという考えから。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
