### PR TITLE
Style 2024.10.19.10.33 member名が編集できることがわかるようにアイコンボタンを実装する #58

### DIFF
--- a/src/resources/css/MatrixView.css
+++ b/src/resources/css/MatrixView.css
@@ -22,7 +22,8 @@
   padding: 10px;
   text-align: center;
   border: 1px solid #ddd;
-  width: 100px;
+  width: 10%;
+  max-width: 10%;
 }
 
 .matrix-side-header {
@@ -30,19 +31,19 @@
   padding: 10px;
   text-align: center;
   border: 1px solid #ddd;
-  width: 100px;
+  width: 10%;
+  max-width: 10%;
 }
 
 td.matrix-cell {
   padding: 8px;
-  min-width: 100px;
-  max-width: 100px;
+  width: 10%;
+  max-width: 10%;
   border: 1px solid #ddd;
 }
 td.matrix-cell.next-step-column {
   padding: 8px;
-  min-width: 50px;
-  max-width: 50px;
+  width: 10%;
   border: 1px solid #ddd;
 }
 

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers, updateMemberName } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUser, faPlus, faArrowUp, faArrowDown, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faUser, faPlus, faArrowUp, faArrowDown, faTrash, faEdit } from '@fortawesome/free-solid-svg-icons';
 import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
@@ -66,7 +66,7 @@ const MatrixCol = ({ openModal, flowNumber, onAssignFlowStep, updateFlowStepNumb
 const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, moveRow, updateFlowStepNumber, onMemberDelete }) => {
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
-    const [newName, setNewName] = useState(member.name); // 初期値を member.name に設定
+    const [newName, setNewName] = useState(member.name); // Set initial value to member.name
 
     const [{ isDragging }, drag] = useDrag(() => ({
         type: 'ROW',
@@ -86,15 +86,12 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
         },
     }), [index, moveRow]);
 
-
     const dispatch = useDispatch();
-
-    // Redux ストアからメンバーリストを取得
     const members = useSelector((state) => state.members); 
     const flowsteps = useSelector((state) => state.flowsteps); 
 
     useEffect(() => {
-        dispatch(fetchMembers()); // コンポーネントがマウントされたときにメンバーを取得
+        dispatch(fetchMembers()); // Fetch members when component mounts
     }, [dispatch]);
 
     const handleNameChange = (e) => {
@@ -102,33 +99,43 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
     };
 
     const handleNameEdit = async () => {
-        // メンバー名を更新するアクションをディスパッチ
+        // Dispatch an action to update the member name
         await dispatch(updateMemberName({ id: member.id, name: newName }));
         setIsEditing(false);
     };
 
     return (
         <tr 
-        ref={(node) => drag(drop(node))} 
+            ref={(node) => drag(drop(node))} 
             style={{ opacity: isDragging ? 0.5 : 1 }} 
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-            style={{ position: 'relative' }}
         >
             <td className="matrix-side-header">
-                <div className="member-cell">
+                <div 
+                    className="member-cell" 
+                    onMouseEnter={() => setIsHovered(true)} 
+                    onMouseLeave={() => setIsHovered(false)}
+                    style={{ display: 'flex', alignItems: 'center', position: 'relative' }}
+                >
                     {isEditing ? (
                         <input 
                             type="text" 
                             value={newName} 
                             onChange={handleNameChange} 
-                            onBlur={handleNameEdit} // フォーカスが外れたときに自動的に保存
-                            onKeyPress={(e) => { if (e.key === 'Enter') handleNameEdit(); }} // Enterで保存
+                            onBlur={handleNameEdit} // Automatically save on blur
+                            onKeyPress={(e) => { if (e.key === 'Enter') handleNameEdit(); }} // Save on Enter
+                            style={{ marginRight: '5px' }} // Space between input and icons
                         />
                     ) : (
                         <>
-                            <div onClick={() => setIsEditing(true)}>{member.name}</div>
-                            <div className="member-icon">
+                            <div onClick={() => setIsEditing(true)} style={{ marginRight: '5px' }}>
+                                {member.name}
+                            </div>
+                            {isHovered && (
+                                <div className="edit-icon" onClick={() => setIsEditing(true)} style={{ marginLeft: '5px' }}>
+                                    <FontAwesomeIcon icon={faEdit} size="1x" />
+                                </div>
+                            )}
+                            <div className="member-icon" style={{ marginRight: '15px' ,marginLeft: 'auto' }}>
                                 <FontAwesomeIcon icon={faUser} size="2x" />
                             </div>
                         </>
@@ -148,7 +155,6 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
                 <MatrixCol
                     key={flowNumber}
                     member={member}
-                    // members={[member]}
                     openModal={openModal}
                     flowNumber={flowNumber}
                     onAssignFlowStep={onAssignFlowStep}


### PR DESCRIPTION
## GitHub Issue Ticket
- close #58 

## やった事
`このプルリクエストにて何をしたのか？`
MatrixView上でmemberの名前付近をホバーすると編集することがわかるように編集アイコンを表示するようにした

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
memberのCRUD機能が使えることを視覚的にわかりやすくした

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
