### PR TITLE
Feature 2024.10.21.22.06 ログインユーザーの作成したmemberレコードのみ表示するようにする #77

### DIFF
--- a/src/app/Http/Controllers/MemberController.php
+++ b/src/app/Http/Controllers/MemberController.php
@@ -11,7 +11,10 @@ class MemberController extends Controller
     public function index()
     {
         // メンバー情報をすべて取得
-        $members = Member::orderBy('order_on_matrix')->get();
+        $members = Member::where('user_id', auth()->id())
+        ->orderBy('order_on_matrix')
+        ->get();
+
 
         // JSON形式で返す（Unicodeエスケープを無効にする）
         return response()->json($members, 200, [], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
@@ -23,15 +26,16 @@ class MemberController extends Controller
         $request->validate([
             'name' => 'required|string|max:255',
         ]);
-
+    
         // データの保存
         $member = new Member();
         $member->name = $request->input('name');
+        $member->user_id = auth()->id(); // ログイン中のユーザーのIDを設定
         $member->save();
-
+    
         return response()->json(['message' => 'Member created successfully!', 'member' => $member], 201);
     }
-    
+          
     public function saveOrder(Request $request)
     {
         // リクエストボディから member_ids を取得

--- a/src/app/Models/Member.php
+++ b/src/app/Models/Member.php
@@ -12,6 +12,11 @@ class Member extends Model
     // ホワイトリストで設定する属性
     protected $fillable = ['name'];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     public function flowsteps()
     {
         return $this->belongsToMany(Flowstep::class);

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -45,4 +45,10 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function members()
+    {
+        return $this->hasMany(Member::class);
+    }
+
 }

--- a/src/database/migrations/2024_10_21_131729_add_user_id_to_members_table.php
+++ b/src/database/migrations/2024_10_21_131729_add_user_id_to_members_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->after('id')->nullable(); // user_idカラムを追加
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+
+};


### PR DESCRIPTION
## GitHub Issue Ticket
- close #77 

## やった事
`このプルリクエストにて何をしたのか？`
MatrixView上のmemberレコードをログインユーザーの作成したレコードのみに限定

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
マトリクスフロー作成画面で自分が作成したもの以外も表示されてしまうため、修正

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
