### PR TITLE
Feature 2024.10.21.23.06 ログインユーザーの作成したflowstepsレコードのみ表示するようにする #79

### DIFF
--- a/src/app/Models/Flowstep.php
+++ b/src/app/Models/Flowstep.php
@@ -9,7 +9,17 @@ class Flowstep extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'flow_number'];
+    protected $fillable = [
+        'name', 
+        'flow_number',
+        'user_id'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
 
     public function workflows()
     {

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -51,4 +51,9 @@ class User extends Authenticatable
         return $this->hasMany(Member::class);
     }
 
+    public function flowsteps()
+    {
+        return $this->hasMany(FlowStep::class);
+    }
+
 }

--- a/src/database/migrations/2024_10_21_134716_add_user_id_to_flowsteps_table.php
+++ b/src/database/migrations/2024_10_21_134716_add_user_id_to_flowsteps_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('flowsteps', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->after('id')->nullable(); // user_idカラムを追加
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade'); // 外部キー制約
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('flowsteps', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+
+};


### PR DESCRIPTION
## GitHub Issue Ticket
- close #79 

## やった事
`このプルリクエストにて何をしたのか？`
MatrixView上にログイン中のユーザーが作成したFlowstepsしか表示しないように実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
ログインユーザー以外のユーザーが作成したFlowStepがMatrixViewに表示されてしまうため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
