### PR TITLE
Style_2024.10.22.00.26_空の.matrix-cellにスタイリング

### DIFF
--- a/src/resources/css/MatrixView.css
+++ b/src/resources/css/MatrixView.css
@@ -36,11 +36,22 @@
 }
 
 td.matrix-cell {
-  padding: 8px;
   width: 10%;
   max-width: 10%;
   border: 1px solid #ddd;
 }
+
+/* MatrixView.css */
+.matrix-empty-cell {
+  height: 100px; /* 高さを指定 */
+  background-color: #f2f2f2; /* 背景色 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+
+
 td.matrix-cell.next-step-column {
   padding: 8px;
   width: 10%;
@@ -124,3 +135,4 @@ td.matrix-cell.next-step-column {
   text-align: center;
   font-size: 24px;
 }
+

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers, updateMemberName } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUser, faPlus, faArrowUp, faArrowDown, faTrash, faEdit } from '@fortawesome/free-solid-svg-icons';
+import { faUser, faPlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBarrier } from '@fortawesome/free-solid-svg-icons';
 import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
@@ -105,25 +105,17 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
     };
 
     return (
-        <tr 
-            ref={(node) => drag(drop(node))} 
-            style={{ opacity: isDragging ? 0.5 : 1 }} 
-        >
+        <tr ref={(node) => drag(drop(node))} style={{ opacity: isDragging ? 0.5 : 1 }}>
             <td className="matrix-side-header">
-                <div 
-                    className="member-cell" 
-                    onMouseEnter={() => setIsHovered(true)} 
-                    onMouseLeave={() => setIsHovered(false)}
-                    style={{ display: 'flex', alignItems: 'center', position: 'relative' }}
-                >
+                <div className="member-cell" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
                     {isEditing ? (
                         <input 
                             type="text" 
                             value={newName} 
                             onChange={handleNameChange} 
-                            onBlur={handleNameEdit} // Automatically save on blur
-                            onKeyPress={(e) => { if (e.key === 'Enter') handleNameEdit(); }} // Save on Enter
-                            style={{ marginRight: '5px' }} // Space between input and icons
+                            onBlur={handleNameEdit} 
+                            onKeyPress={(e) => { if (e.key === 'Enter') handleNameEdit(); }} 
+                            style={{ marginRight: '5px' }} 
                         />
                     ) : (
                         <>
@@ -135,7 +127,7 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
                                     <FontAwesomeIcon icon={faEdit} size="1x" />
                                 </div>
                             )}
-                            <div className="member-icon" style={{ marginRight: '15px' ,marginLeft: 'auto' }}>
+                            <div className="member-icon" style={{ marginRight: '15px', marginLeft: 'auto' }}>
                                 <FontAwesomeIcon icon={faUser} size="2x" />
                             </div>
                         </>
@@ -162,10 +154,7 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
                 />
             ))}
             <td className="matrix-cell next-step-column">
-                <button
-                    className="add-step-button"
-                    onClick={() => openModal(member, maxFlowNumber + 1)}
-                >
+                <button className="add-step-button" onClick={() => openModal(member, maxFlowNumber + 1)}>
                     <FontAwesomeIcon icon={faPlus} />
                 </button>
             </td>
@@ -321,16 +310,13 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
                                         <AddMemberForm onMemberAdded={handleMemberAdded} />
                                     </div>
                                 </td>
-                                {Array.from({ length: maxFlowNumber }, (_, i) => i + 1).map((flowNumber) => (
-                                    <td key={flowNumber} className="matrix-cell">
-                                        <div></div>
+                                {Array.from({ length: maxFlowNumber }, (_, i) => (
+                                    <td key={i} className="matrix-cell">
+                                        <div className="matrix-empty-cell"><FontAwesomeIcon icon={faRoadBarrier} color="navy" size="1x" /></div> {/* This keeps the cell empty for alignment */}
                                     </td>
                                 ))}
                                 <td className="matrix-cell next-step-column">
-                                    <button 
-                                        className="add-step-button" 
-                                        onClick={() => openModal(null, maxFlowNumber + 1)}
-                                    >
+                                    <button onClick={() => openModal(null, maxFlowNumber + 1)} className="add-step-button">
                                         <FontAwesomeIcon icon={faPlus} />
                                     </button>
                                 </td>


### PR DESCRIPTION
## GitHub Issue Ticket
- close #81 

## やった事
`このプルリクエストにて何をしたのか？`
MatrixView最下行のFlowStepがないセルが何も表示されていないため
MatrixViewが凹形になってしまっているのを空のセルにスタイルを追加して長方形にした

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
MatrixViewの見栄えを改善

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
