### PR TITLE
Feature 2024.10.23.20.54 matrix viewの内容から文書を作成できる機能を実装する #91

### DIFF
--- a/src/app/Http/Controllers/FlowstepController.php
+++ b/src/app/Http/Controllers/FlowstepController.php
@@ -82,16 +82,5 @@ class FlowstepController extends Controller
 
         return response()->json($flowStep, 200); // Return updated flow step
     }
-
-    public function getFlowstepWithMembers($flowstepId)
-    {
-        $flowstep = Flowstep::with('members')->find($flowstepId);
-
-        if (!$flowstep) {
-            return response()->json(['message' => 'Flowstep not found'], 404);
-        }
-
-        return response()->json($flowstep);
-    }
     
 }

--- a/src/app/Http/Controllers/FlowstepController.php
+++ b/src/app/Http/Controllers/FlowstepController.php
@@ -82,5 +82,16 @@ class FlowstepController extends Controller
 
         return response()->json($flowStep, 200); // Return updated flow step
     }
+
+    public function getFlowstepWithMembers($flowstepId)
+    {
+        $flowstep = Flowstep::with('members')->find($flowstepId);
+
+        if (!$flowstep) {
+            return response()->json(['message' => 'Flowstep not found'], 404);
+        }
+
+        return response()->json($flowstep);
+    }
     
 }

--- a/src/app/Models/Flowstep.php
+++ b/src/app/Models/Flowstep.php
@@ -26,8 +26,11 @@ class Flowstep extends Model
         return $this->belongsToMany(Workflow::class);
     }
 
+    protected $table = 'flowsteps'; // 既存の flowsteps テーブル
+
     public function members()
     {
-        return $this->belongsToMany(Member::class);
+        // 中間テーブル flowstep_member を介して members を取得するリレーション
+        return $this->belongsToMany(Member::class, 'flowstep_member', 'flowstep_id', 'member_id');
     }
 }

--- a/src/app/Models/Member.php
+++ b/src/app/Models/Member.php
@@ -17,8 +17,12 @@ class Member extends Model
         return $this->belongsTo(User::class);
     }
 
+    protected $table = 'members'; // 既存の members テーブル
+
     public function flowsteps()
     {
-        return $this->belongsToMany(Flowstep::class);
+        // 中間テーブル flowstep_member を介して flowsteps を取得するリレーション
+        return $this->belongsToMany(Flowstep::class, 'flowstep_member', 'member_id', 'flowstep_id');
     }
+
 }

--- a/src/resources/css/CreateMatrixFlowPage.css
+++ b/src/resources/css/CreateMatrixFlowPage.css
@@ -10,6 +10,10 @@
   color: #333; /* テキスト色 */
 }
 
+.content-container {
+  display: flex;
+}
+
 .flash-message {
   background-color: rgba(255, 255, 255, 0.9); /* フラッシュメッセージの背景 */
   border: 1px solid #ccc; /* 境界線 */

--- a/src/resources/css/Document.css
+++ b/src/resources/css/Document.css
@@ -1,0 +1,39 @@
+.document-container {
+  padding: 40px;
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #fff; /* 白背景 */
+  border: 1px solid #ccc; /* 薄い枠線 */
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  font-family: 'Arial', sans-serif; /* 一般的なフォント */
+  line-height: 1.6; /* 行間を広げる */
+}
+
+.document-container h2 {
+  font-size: 28px; /* 見出しのフォントサイズ */
+  color: #333; /* 見出しの色 */
+  margin-bottom: 20px; /* 見出し下の余白 */
+  text-align: left; /* 左揃え */
+}
+
+.chapter {
+  margin-bottom: 30px; /* 各章の下余白 */
+}
+
+.chapter h3 {
+  font-size: 24px; /* 章の見出しのフォントサイズ */
+  color: #555; /* 章見出しの色 */
+  margin-bottom: 10px; /* 章見出しの下余白 */
+}
+
+.chapter p {
+  font-size: 18px; /* 段落のフォントサイズ */
+  color: #666; /* 段落の色 */
+  margin: 5px 0; /* 段落の上下余白 */
+}
+
+.chapter p span {
+  font-weight: bold; /* 太字 */
+  color: #2c3e50; /* 強調色 */
+}

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { fetchFlowsteps } from '../store/flowstepsSlice'; 
+import axios from 'axios';
+import '../../css/Document.css'
+
+const Document = () => {
+  const dispatch = useDispatch();
+
+  const [flowsteps, setFlowsteps] = useState([]);
+  
+
+  useEffect(() => {
+    dispatch(fetchFlowsteps());
+  }, [dispatch]);
+
+
+  useEffect(() => {
+    const fetchFlowstepsWithMembers = async () => {
+      try {
+        const response = await axios.get('/api/flowsteps'); // すべてのFlowstepを取得するAPI
+        const flowstepsWithMembers = await Promise.all(
+          response.data.map(async (flowstep) => {
+            const res = await axios.get(`/api/flowsteps/${flowstep.id}/members`);
+            return res.data;
+          })
+        );
+        setFlowsteps(flowstepsWithMembers);
+      } catch (error) {
+        console.error('Error fetching flowsteps:', error);
+      }
+    };
+
+    fetchFlowstepsWithMembers();
+  }, []);
+
+  return (
+    <div className="document-container">
+      <h2>Document</h2>
+      {flowsteps.map((flowstep, index) => (
+        <div key={flowstep.id} className="chapter">
+          <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
+          <p>
+            {flowstep.members.length > 0
+              ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
+              : 'Unknown Member が行うタスク:'}
+            {flowstep.content}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Document;

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -1,38 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchFlowsteps } from '../store/flowstepsSlice'; 
-import axios from 'axios';
 import '../../css/Document.css'
 
 const Document = () => {
   const dispatch = useDispatch();
-
-  const [flowsteps, setFlowsteps] = useState([]);
   
+  // Get flowsteps from Redux store
+  const flowsteps = useSelector((state) => state.flowsteps);
 
   useEffect(() => {
+    // Fetch flowsteps on component mount
     dispatch(fetchFlowsteps());
   }, [dispatch]);
-
-
-  useEffect(() => {
-    const fetchFlowstepsWithMembers = async () => {
-      try {
-        const response = await axios.get('/api/flowsteps'); // すべてのFlowstepを取得するAPI
-        const flowstepsWithMembers = await Promise.all(
-          response.data.map(async (flowstep) => {
-            const res = await axios.get(`/api/flowsteps/${flowstep.id}/members`);
-            return res.data;
-          })
-        );
-        setFlowsteps(flowstepsWithMembers);
-      } catch (error) {
-        console.error('Error fetching flowsteps:', error);
-      }
-    };
-
-    fetchFlowstepsWithMembers();
-  }, []);
 
   return (
     <div className="document-container">
@@ -41,7 +21,7 @@ const Document = () => {
         <div key={flowstep.id} className="chapter">
           <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
           <p>
-            {flowstep.members.length > 0
+            {flowstep.members && flowstep.members.length > 0
               ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
               : 'Unknown Member が行うタスク:'}
             {flowstep.content}

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -69,14 +69,16 @@ const CreateMatrixFlowPage = () => {
         <AuthenticatedLayout>
             <div className="welcome-container">
                 <FlashMessage message={flashMessage} />
-                <MatrixView
-                    members={members}
-                    flowsteps={flowsteps}
-                    onAssignFlowStep={handleAssignFlowStep}
-                    onMemberAdded={handleMemberAdded}
-                    onFlowStepAdded={handleFlowStepAdded}
-                />
-                <Document />
+                <div className="content-container">
+                    <Document />
+                    <MatrixView
+                        members={members}
+                        flowsteps={flowsteps}
+                        onAssignFlowStep={handleAssignFlowStep}
+                        onMemberAdded={handleMemberAdded}
+                        onFlowStepAdded={handleFlowStepAdded}
+                    />
+                </div>
             </div>
         </AuthenticatedLayout>
     );

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -3,9 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers } from '../store/memberSlice'; 
 import { assignFlowStep } from '../store/flowstepsSlice'; 
 import MatrixView from '../Components/MatrixView';
+import Document from '../Components/Document';
 import FlashMessage from '../Components/FlashMessage';
 import '../../css/CreateMatrixFlowPage.css'; // CSSファイルをインポート
-import { Inertia } from '@inertiajs/inertia'; // Inertiaオブジェクトのインポート
 import AuthenticatedLayout from '../Layouts/AuthenticatedLayout'; // AuthenticatedLayoutをインポート
 
 const CreateMatrixFlowPage = () => {
@@ -76,6 +76,7 @@ const CreateMatrixFlowPage = () => {
                     onMemberAdded={handleMemberAdded}
                     onFlowStepAdded={handleFlowStepAdded}
                 />
+                <Document />
             </div>
         </AuthenticatedLayout>
     );

--- a/src/resources/js/store/flowstepsSlice.js
+++ b/src/resources/js/store/flowstepsSlice.js
@@ -1,4 +1,5 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
 
 // Sliceの定義
 export const flowstepsSlice = createSlice({
@@ -6,23 +7,23 @@ export const flowstepsSlice = createSlice({
   initialState: [],
   reducers: {
     setFlowsteps: (state, action) => {
-      return action.payload; // Sets new flowsteps array
+      return action.payload; // 新しいFlowStepの配列を設定
     },
     deleteFlowstep: (state, action) => {
       const updatedFlowsteps = state.filter(flowstep => flowstep.id !== action.payload);
-      console.log('Updated flowsteps after deletion:', updatedFlowsteps); // Debug
+      console.log('Updated flowsteps after deletion:', updatedFlowsteps); // デバッグ
       return updatedFlowsteps;
     },
     editFlowstep: (state, action) => {
       const { id, updatedFlowstep } = action.payload;
       return state.map(flowstep =>
         flowstep.id === id ? { ...flowstep, ...updatedFlowstep } : flowstep
-      ); // Update the specific flowstep
+      ); // 特定のFlowStepを更新
     },
   },
 });
 
-// FlowStepをサーバーから取得するアクション
+// FlowStepを取得するアクション
 export const fetchFlowsteps = () => async (dispatch) => {
   const response = await fetch('/api/flowsteps');
   const data = await response.json();
@@ -44,11 +45,11 @@ export const addFlowstep = (newFlowstep) => async (dispatch) => {
     },
     body: JSON.stringify(newFlowstep),
   });
-  
+
   const data = await response.json();
   // 追加が成功した場合に再フェッチ
   if (response.ok) {
-    dispatch(fetchFlowsteps()); // 新しいフローステップを追加した後、最新のリストを取得
+    dispatch(fetchFlowsteps()); // 新しいFlowStepを追加した後、最新のリストを取得
   }
 };
 
@@ -87,28 +88,28 @@ export const deleteFlowstepAsync = (id) => async (dispatch) => {
 export const assignFlowStep = createAsyncThunk(
   'flowsteps/assignFlowStep',
   async ({ memberId, flowstepId, assignedMembersBeforeDrop }, { dispatch, rejectWithValue }) => {
-      try {
-          const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-          const response = await fetch('/api/assign-flowstep', {
-              method: 'POST',
-              headers: {
-                  'Content-Type': 'application/json',
-                  'X-CSRF-TOKEN': token,
-              },
-              body: JSON.stringify({ memberId, flowstepId, assignedMembersBeforeDrop }),
-          });
-          if (!response.ok) {
-              return rejectWithValue('Failed to assign FlowStep');
-          }
-          const result = await response.json(); // Return the updated data or a success message
-          dispatch(fetchFlowsteps()); // 割り当て後に再フェッチ
-          return result; // 必要に応じて戻り値を変更
-      } catch (error) {
-          return rejectWithValue(error.message);
+    try {
+      const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+      const response = await fetch('/api/assign-flowstep', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': token,
+        },
+        body: JSON.stringify({ memberId, flowstepId, assignedMembersBeforeDrop }),
+      });
+      if (!response.ok) {
+        return rejectWithValue('Failed to assign FlowStep');
+      }
+      const result = await response.json(); // Return the updated data or a success message
+      dispatch(fetchFlowsteps()); // 割り当て後に再フェッチ
+      return result; // 必要に応じて戻り値を変更
+    } catch (error) {
+      return rejectWithValue(error.message);
+    }
   }
-});    
+);
 
-// FlowStepを編集するアクション
 // FlowStepを編集するアクション
 export const updateFlowstepAsync = createAsyncThunk(
   'flowsteps/updateFlowstep',

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -41,6 +41,8 @@ Route::post('/api/flowsteps', [FlowstepController::class, 'store']);
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);
 Route::put('/api/flowsteps/{id}', [FlowStepController::class, 'update']);
+Route::get('/api/flowsteps/{flowstepId}/members', [FlowstepController::class, 'getFlowstepWithMembers']);
+
 
 use App\Http\Controllers\FlowstepMemberController;
 Route::post('/api/assign-flowstep', [FlowstepMemberController::class, 'store']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -41,7 +41,6 @@ Route::post('/api/flowsteps', [FlowstepController::class, 'store']);
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);
 Route::put('/api/flowsteps/{id}', [FlowStepController::class, 'update']);
-Route::get('/api/flowsteps/{flowstepId}/members', [FlowstepController::class, 'getFlowstepWithMembers']);
 
 
 use App\Http\Controllers\FlowstepMemberController;


### PR DESCRIPTION
## GitHub Issue Ticket
- close #91 

## やった事
`このプルリクエストにて何をしたのか？`
MatrixViewの内容から文書を作成できる機能を実装
 - Laravel
   - 変更点は特になし
 - React
   - Documentコンポーネントを作成
   - DocumentコンポーネントでstoreからFlowstepの情報を参照して非同期レンダリングするよう実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
MatrixViewでマトリクスを作ることにより効率化できることを増やす。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
