### PR TITLE
Feature_2024.10.25.04.07_WorkflowモデルとMemberモデル / Flowstepモデルの紐付けによるapi移管

### DIFF
--- a/src/app/Http/Controllers/FlowstepController.php
+++ b/src/app/Http/Controllers/FlowstepController.php
@@ -3,18 +3,21 @@
 namespace App\Http\Controllers;
 
 use App\Models\Flowstep;
+use App\Models\Workflow;
 use Illuminate\Http\Request;
 
 class FlowstepController extends Controller
 {
-    public function index()
+    // メンバー情報を取得するメソッド
+    public function index($workflowId)
     {
-        // ログイン中のユーザーが作成したフローステップと関連するメンバー情報を取得
-        $flowsteps = Flowstep::with('members')
-            -> where('user_id', auth()->id())
+        // Get all members for the specified workflow and the logged-in user
+        $flowsteps = Flowstep::where('user_id', auth()->id())
+            ->where('workflow_id', $workflowId) // Ensure you have a workflow_id field in your members table
             ->get();
     
-        return response()->json($flowsteps);
+        // JSON response
+        return response()->json($flowsteps, 200, [], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
     }
     
     public function store(Request $request)

--- a/src/app/Http/Controllers/MatrixFlowController.php
+++ b/src/app/Http/Controllers/MatrixFlowController.php
@@ -7,6 +7,15 @@ use Illuminate\Http\Request;
 
 class MatrixFlowController extends Controller
 {
+    // ページ遷移
+    public function renderNewMatrixFlowPage()
+    {
+        // Inertia::render を使ってフロントエンドにデータとページを送る
+        return Inertia::render('NewMatrixFlowPage', [
+            'flowData' => 'Sample data for the matrix flow',
+        ]);
+    }
+
     public function renderCreateMatrixFlowPage()
     {
         // Inertia::render を使ってフロントエンドにデータとページを送る
@@ -14,6 +23,7 @@ class MatrixFlowController extends Controller
             'flowData' => 'Sample data for the matrix flow',
         ]);
     }
+    
     public function renderCreateMatrixFlowPageforGuest()
     {
         // Inertia::render を使ってフロントエンドにデータとページを送る

--- a/src/app/Models/Member.php
+++ b/src/app/Models/Member.php
@@ -10,7 +10,12 @@ class Member extends Model
     use HasFactory;
 
     // ホワイトリストで設定する属性
-    protected $fillable = ['name'];
+    protected $fillable = [
+        'user_id',
+        'workflow_id',
+        'name',
+        'order_on_matrix'
+    ];
 
     public function user()
     {

--- a/src/database/migrations/2024_10_24_124122_add_workflow_id_to_members_table.php
+++ b/src/database/migrations/2024_10_24_124122_add_workflow_id_to_members_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWorkflowIdToMembersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->unsignedBigInteger('workflow_id')->after('user_id')->nullable(); // Adding the new column
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dropColumn('workflow_id'); // Dropping the column in case of rollback
+        });
+    }
+}

--- a/src/database/migrations/2024_10_24_164219_add_workflow_id_to_flowsteps_table.php
+++ b/src/database/migrations/2024_10_24_164219_add_workflow_id_to_flowsteps_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('flowsteps', function (Blueprint $table) {
+            $table->unsignedBigInteger('workflow_id')->nullable(); // adjust type and options as needed
+        });
+    }
+    
+    public function down()
+    {
+        Schema::table('flowsteps', function (Blueprint $table) {
+            $table->dropColumn('workflow_id');
+        });
+    }
+    
+};

--- a/src/resources/js/Components/AddMemberForm.jsx
+++ b/src/resources/js/Components/AddMemberForm.jsx
@@ -1,33 +1,43 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import { useDispatch } from 'react-redux';
+import { addMember } from '../store/memberSlice'; // アクションのパスを正確に指定
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import '../../css/AddMemberForm.css';
 
-const AddMemberForm = ({ onMemberAdded }) => {
+const AddMemberForm = ({ workflowId }) => {
     const [name, setName] = useState('');
+    const [error, setError] = useState(null);
+    const [successMessage, setSuccessMessage] = useState(null);
+    const dispatch = useDispatch(); // Dispatch を取得
 
     useEffect(() => {
-        // CSRFトークンを取得してaxiosに設定
         const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
         axios.defaults.headers.common['X-CSRF-TOKEN'] = token;
     }, []);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+        setError(null);
+        setSuccessMessage(null);
+    
+        const memberData = { name }; // 送信するデータを準備
+        console.log('Sending data:', memberData, 'to workflowId:', workflowId); // 送信されるデータをログ
+    
         try {
-            const response = await axios.post('/api/members', { name });
-            setName(''); // フォームをクリア
-            if (onMemberAdded) {
-                onMemberAdded(name); // 追加したメンバーの名前を親コンポーネントに渡す
-            }
+            // Reduxアクションをディスパッチ
+            const action = await dispatch(addMember({ workflowId, newMember: memberData })).unwrap();
+            setName(''); // 入力をクリア
+            console.log('Member added:', action); // 成功した場合の処理
         } catch (error) {
-            console.error('Error adding member:', error);
+            console.error('Error adding member:', error); // エラーの詳細をログ
+            setError('Failed to add member.'); // エラーメッセージを設定
         }
     };
-
+    
     return (
         <form onSubmit={handleSubmit} className="mb-4">
+            {error && <div className="error-message">{error}</div>}
             <div className="form-row">
                 <div>
                     <input

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchFlowsteps } from '../store/flowstepsSlice'; 
-import '../../css/Document.css'
+import '../../css/Document.css';
 
 const Document = () => {
   const dispatch = useDispatch();
-  
+
   // Get flowsteps from Redux store
   const flowsteps = useSelector((state) => state.flowsteps);
 
@@ -14,20 +14,29 @@ const Document = () => {
     dispatch(fetchFlowsteps());
   }, [dispatch]);
 
+  // flowstepsが配列であることを確認
+  if (!Array.isArray(flowsteps)) {
+    return <div>Error: flowsteps is not an array.</div>;
+  }
+
   return (
     <div className="document-container">
       <h2>文書</h2>
-      {flowsteps.map((flowstep, index) => (
-        <div key={flowstep.id} className="chapter">
-          <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
-          <p>
-            {flowstep.members && flowstep.members.length > 0
-              ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
-              : 'Unknown Member が行うタスク:'}
-            {flowstep.content}
-          </p>
-        </div>
-      ))}
+      {flowsteps.length === 0 ? (
+        <p>フローステップはまだありません。</p>
+      ) : (
+        flowsteps.map((flowstep, index) => (
+          <div key={flowstep.id} className="chapter">
+            <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
+            <p>
+              {flowstep.members && flowstep.members.length > 0
+                ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
+                : 'Unknown Member が行うタスク:'}
+              {flowstep.content}
+            </p>
+          </div>
+        ))
+      )}
     </div>
   );
 };

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import { useDrag } from 'react-dnd';
 import '../../css/Flowstep.css';
 import { useDispatch } from 'react-redux';
-import { deleteFlowstepAsync, updateFlowstepAsync } from '../store/flowstepsSlice'; // Import the async actions
+import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepAsync } from '../store/flowstepsSlice'; // Import the async actions
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit, faSave, faCancel } from '@fortawesome/free-solid-svg-icons';
 
-const FlowStep = ({ flowstep }) => {
+const FlowStep = ({ flowstep, workflowId }) => {
     if (!flowstep) {
         return <div>フローステップのデータがありません</div>;
     }
@@ -44,6 +44,7 @@ const FlowStep = ({ flowstep }) => {
         e.preventDefault();
         await dispatch(updateFlowstepAsync({ id: flowstep.id, updatedFlowstep: { name: newName } }));
         setIsEditing(false); // Close the form after submitting
+        dispatch(fetchFlowsteps(workflowId));
     };
 
     return (

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -267,6 +267,7 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
     const handleUpdateFlowStepNumber = async (flowStepId, newFlowNumber) => {
         // ReduxのupdateFlowStepNumberをdispatch
         dispatch(updateFlowStepNumber({ flowStepId, newFlowNumber }));
+        dispatch(fetchFlowsteps(workflowId));
     };
 
     const handleMemberDelete = (memberId) => {

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { fetchMembers, updateMemberName } from '../store/memberSlice';
+import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser, faPlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBarrier } from '@fortawesome/free-solid-svg-icons';
@@ -253,24 +253,14 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
         dispatch(updateFlowStepNumber({ flowStepId, newFlowNumber }));
     };
 
-    const handleMemberDelete = async (memberId) => {
-        try {
-            const response = await fetch(`/api/members/${memberId}`, {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN': csrfToken,
-                },
+    const handleMemberDelete = (memberId) => {
+        dispatch(deleteMember(memberId))
+            .then(() => {
+                dispatch(fetchMembers(workflowId)); // Refresh members after deletion
+            })
+            .catch((error) => {
+                console.error('Error deleting member:', error);
             });
-
-            if (response.ok) {
-                console.log(`Member with ID ${memberId} deleted successfully.`);
-                dispatch(fetchMembers()); // Refresh members from Redux
-            } else {
-                console.error('Failed to delete member.');
-            }
-        } catch (error) {
-            console.error('Error deleting member:', error);
-        }
     };
 
     return (

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -71,9 +71,11 @@ const CreateMatrixFlowPage = () => {
             .catch((error) => {
                 console.error('Error assigning FlowStep:', error);
                 setFlashMessage("Failed to assign FlowStep");
-            });
+        });
 
         setTimeout(() => setFlashMessage(''), 5000);
+        dispatch(fetchFlowsteps(workflowId));
+
     };
 
     return (

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers } from '../store/memberSlice'; 
-import { assignFlowStep } from '../store/flowstepsSlice'; 
+import { fetchFlowsteps, assignFlowStep } from '../store/flowstepsSlice'; 
+import { useParams } from 'react-router-dom';
 import MatrixView from '../Components/MatrixView';
 import Document from '../Components/Document';
 import FlashMessage from '../Components/FlashMessage';
@@ -14,13 +15,15 @@ const CreateMatrixFlowPage = () => {
     const [membersUpdated, setMembersUpdated] = useState(false);
     const [flowstepsUpdated, setFlowstepsUpdated] = useState(false);
     const [flashMessage, setFlashMessage] = useState('');
-    const [workflowId, setWorkflowId] = useState(null); // 一意のワークフローIDを保存
+    const { workflowId } = useParams();
 
     const members = useSelector((state) => state.members);
 
     useEffect(() => {
-        dispatch(fetchMembers());
-    }, [dispatch]);
+        dispatch(fetchMembers(workflowId)); // workflowIdに基づいてメンバーを取得
+        console.log('Fetched members:', members);
+        dispatch(fetchFlowsteps(workflowId)); // workflowIdに基づいてフローステップを取得
+    }, [dispatch, workflowId]);
 
     const handleCreateWorkflow = async () => {
         try {
@@ -72,16 +75,6 @@ const CreateMatrixFlowPage = () => {
 
         setTimeout(() => setFlashMessage(''), 5000);
     };
-
-    useEffect(() => {
-        const fetchFlowsteps = async () => {
-            const response = await fetch('/api/flowsteps');
-            const data = await response.json();
-            setFlowsteps(data);
-        };
-
-        fetchFlowsteps();
-    }, [flowstepsUpdated]);
 
     return (
         <AuthenticatedLayout>

--- a/src/resources/js/app.jsx
+++ b/src/resources/js/app.jsx
@@ -10,7 +10,7 @@ import { DndProvider } from 'react-dnd'; // react-dnd の DndProvider をイン�
 import { HTML5Backend } from 'react-dnd-html5-backend'; // HTML5Backend をインポート
 import Layout from './Layouts/Layout';
 import { Helmet } from 'react-helmet';
-
+import { BrowserRouter, Route, Routes } from 'react-router-dom'; // BrowserRouterとRouteをインポート
 
 // CSRFトークンを取得する関数（nullチェックを追加）
 const csrfToken = () => {
@@ -24,7 +24,6 @@ axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken();
 
 const appName = import.meta.env.VITE_APP_NAME || 'matrixflow';
 
-
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     resolve: (name) =>
@@ -36,21 +35,22 @@ createInertiaApp({
         const root = createRoot(el);
 
         root.render(
-            <>
+            <BrowserRouter> {/* BrowserRouterでラップ */}
                 <Provider store={store}>
                     <DndProvider backend={HTML5Backend}>
                         <Layout>
-                        <Helmet>
-                            <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-                        </Helmet>
-
-                            <App {...props} />
+                            <Helmet>
+                                <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+                            </Helmet>
+                            <Routes> {/* Routesコンポーネントでラップ */}
+                                <Route path="/create-matrixflow/:workflowId" element={<App {...props} />} />
+                                {/* 他のルートを必要に応じて追加 */}
+                            </Routes>
                         </Layout>
                     </DndProvider>
                 </Provider>
-            </>
+            </BrowserRouter>
         );
-        
     },
     progress: {
         color: '#4B5563',

--- a/src/resources/js/store/flowstepsSlice.js
+++ b/src/resources/js/store/flowstepsSlice.js
@@ -1,57 +1,42 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
-// Sliceの定義
-export const flowstepsSlice = createSlice({
-  name: 'flowsteps',
-  initialState: [],
-  reducers: {
-    setFlowsteps: (state, action) => {
-      return action.payload; // 新しいFlowStepの配列を設定
-    },
-    deleteFlowstep: (state, action) => {
-      const updatedFlowsteps = state.filter(flowstep => flowstep.id !== action.payload);
-      console.log('Updated flowsteps after deletion:', updatedFlowsteps); // デバッグ
-      return updatedFlowsteps;
-    },
-    editFlowstep: (state, action) => {
-      const { id, updatedFlowstep } = action.payload;
-      return state.map(flowstep =>
-        flowstep.id === id ? { ...flowstep, ...updatedFlowstep } : flowstep
-      ); // 特定のFlowStepを更新
-    },
-  },
-});
 
 // FlowStepを取得するアクション
-export const fetchFlowsteps = () => async (dispatch) => {
-  const response = await fetch('/api/flowsteps');
-  const data = await response.json();
-  if (response.ok) {
-    dispatch(flowstepsSlice.actions.setFlowsteps(data)); // 取得したデータで状態を更新
-  } else {
-    // エラーハンドリング
-    console.error('Error fetching flowsteps:', data);
+export const fetchFlowsteps = createAsyncThunk(
+  'flowsteps/fetchFlowsteps',
+  async (workflowId, { dispatch, rejectWithValue }) => {
+    try {
+      const response = await axios.get(`/api/workflows/${workflowId}/flowsteps`);
+      
+      if (response.status !== 200) {
+        throw new Error('Failed to fetch flowsteps');
+      }
+
+      const data = response.data;
+
+      dispatch(setFlowsteps(data)); // Assuming setMembers is your action for setting members
+
+      return data; // Return the data if needed
+    } catch (error) {
+      return rejectWithValue(error.message); // Handle error
+    }
   }
-};
+);
 
 // FlowStepを追加するアクション
-export const addFlowstep = (newFlowstep) => async (dispatch) => {
-  const response = await fetch('/api/flowsteps', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-    },
-    body: JSON.stringify(newFlowstep),
-  });
-
-  const data = await response.json();
-  // 追加が成功した場合に再フェッチ
-  if (response.ok) {
-    dispatch(fetchFlowsteps()); // 新しいFlowStepを追加した後、最新のリストを取得
+export const addFlowstep = createAsyncThunk(
+  'flowsteps/addFlowstep',
+  async ({ workflowId, newFlowstep }, { rejectWithValue }) => {
+      try {
+          const response = await axios.post(`/api/workflows/${workflowId}/flowsteps`, newFlowstep);
+          return response.data; // レスポンスデータを返す
+      } catch (error) {
+          return rejectWithValue(error.response?.data || error.message);
+      }
   }
-};
+);
+
 
 // FlowStepを削除するアクション
 export const deleteFlowstepAsync = (id) => async (dispatch) => {
@@ -174,6 +159,37 @@ export const updateFlowStepNumber = createAsyncThunk(
     }
   }
 );
+
+// Sliceの定義
+export const flowstepsSlice = createSlice({
+  name: 'flowsteps',
+  initialState: [],
+  reducers: {
+    setFlowsteps: (state, action) => {
+      return action.payload; // 新しいFlowStepの配列を設定
+    },
+    deleteFlowstep: (state, action) => {
+      const updatedFlowsteps = state.filter(flowstep => flowstep.id !== action.payload);
+      console.log('Updated flowsteps after deletion:', updatedFlowsteps); // デバッグ
+      return updatedFlowsteps;
+    },
+    editFlowstep: (state, action) => {
+      const { id, updatedFlowstep } = action.payload;
+      return state.map(flowstep =>
+        flowstep.id === id ? { ...flowstep, ...updatedFlowstep } : flowstep
+      ); // 特定のFlowStepを更新
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+        .addCase(fetchFlowsteps.fulfilled, (state, action) => {
+            return action.payload; // ステートを新しいメンバーリストで更新
+        })
+        .addCase(addFlowstep.fulfilled, (state, action) => {
+            state.push(action.payload); // 新しいメンバーを追加
+        })
+  },
+});
 
 // Export actions
 export const { setFlowsteps, deleteFlowstep, editFlowstep } = flowstepsSlice.actions;

--- a/src/resources/js/store/memberSlice.js
+++ b/src/resources/js/store/memberSlice.js
@@ -1,6 +1,29 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios'; // Axiosをインポート
 
+// Memberを取得するアクション
+export const fetchMembers = createAsyncThunk(
+    'members/fetchMembers',
+    async (workflowId, { dispatch, rejectWithValue }) => {
+      try {
+        const response = await axios.get(`/api/workflows/${workflowId}/members`);
+        
+        if (response.status !== 200) {
+          throw new Error('Failed to fetch members');
+        }
+  
+        const data = response.data;
+  
+        dispatch(setMembers(data)); // Assuming setMembers is your action for setting members
+  
+        return data; // Return the data if needed
+      } catch (error) {
+        return rejectWithValue(error.message); // Handle error
+      }
+    }
+);
+
+
 // メンバー追加のための非同期関数
 export const addMember = createAsyncThunk(
     'members/addMember',
@@ -43,27 +66,6 @@ export const deleteMember = createAsyncThunk('members/deleteMember', async (memb
         return rejectWithValue(error.message);
     }
 });
-
-export const fetchMembers = createAsyncThunk(
-    'members/fetchMembers',
-    async (workflowId, { dispatch, rejectWithValue }) => {
-      try {
-        const response = await axios.get(`/api/workflows/${workflowId}/members`);
-        
-        if (response.status !== 200) {
-          throw new Error('Failed to fetch members');
-        }
-  
-        const data = response.data;
-  
-        dispatch(setMembers(data)); // Assuming setMembers is your action for setting members
-  
-        return data; // Return the data if needed
-      } catch (error) {
-        return rejectWithValue(error.message); // Handle error
-      }
-    }
-  );
   
 const memberSlice = createSlice({
     name: 'members',

--- a/src/resources/js/store/memberSlice.js
+++ b/src/resources/js/store/memberSlice.js
@@ -26,14 +26,22 @@ export const updateMemberName = createAsyncThunk('members/updateMemberName', asy
 });
 
 // メンバー削除のための非同期関数
-export const deleteMember = createAsyncThunk('members/deleteMember', async (memberId) => {
-    const response = await axios.delete(`/api/members/${memberId}`); // Axiosを使ってDELETEリクエスト
+export const deleteMember = createAsyncThunk('members/deleteMember', async (memberId, { rejectWithValue }) => {
+    try {
+        const response = await fetch(`/api/members/${memberId}`, {
+            method: 'DELETE',
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+            },
+        });
 
-    if (response.status !== 200) {
-        throw new Error('Failed to delete member');
+        if (!response.ok) {
+            throw new Error('Failed to delete member');
+        }
+        return memberId; // Return the deleted memberId for the reducer
+    } catch (error) {
+        return rejectWithValue(error.message);
     }
-
-    return memberId; // 削除したメンバーのIDを返す
 });
 
 export const fetchMembers = createAsyncThunk(
@@ -79,9 +87,6 @@ const memberSlice = createSlice({
                     state[index] = action.payload; // メンバー名を更新
                 }
             })
-            .addCase(deleteMember.fulfilled, (state, action) => {
-                return state.filter(member => member.id !== action.payload); // 削除したメンバーをリストから除外
-            });
     },
 });
 

--- a/src/resources/js/store/memberSlice.js
+++ b/src/resources/js/store/memberSlice.js
@@ -2,15 +2,17 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios'; // Axiosをインポート
 
 // メンバー追加のための非同期関数
-export const addMember = createAsyncThunk('members/addMember', async (newMember) => {
-    const response = await axios.post('/api/members', newMember); // Axiosを使ってPOSTリクエスト
-
-    if (response.status !== 200) {
-        throw new Error('Failed to add member');
+export const addMember = createAsyncThunk(
+    'members/addMember',
+    async ({ workflowId, newMember }, { rejectWithValue }) => {
+        try {
+            const response = await axios.post(`/api/workflows/${workflowId}/members`, newMember);
+            return response.data; // レスポンスデータを返す
+        } catch (error) {
+            return rejectWithValue(error.response?.data || error.message);
+        }
     }
-
-    return response.data; // レスポンスデータを返す
-});
+);
 
 // メンバー名更新のための非同期関数
 export const updateMemberName = createAsyncThunk('members/updateMemberName', async ({ id, name }) => {
@@ -34,17 +36,27 @@ export const deleteMember = createAsyncThunk('members/deleteMember', async (memb
     return memberId; // 削除したメンバーのIDを返す
 });
 
-// メンバー一覧取得のための非同期関数
-export const fetchMembers = createAsyncThunk('members/fetchMembers', async () => {
-    const response = await axios.get('/api/members'); // Axiosを使ってGETリクエスト
-
-    if (response.status !== 200) {
-        throw new Error('Failed to fetch members');
+export const fetchMembers = createAsyncThunk(
+    'members/fetchMembers',
+    async (workflowId, { dispatch, rejectWithValue }) => {
+      try {
+        const response = await axios.get(`/api/workflows/${workflowId}/members`);
+        
+        if (response.status !== 200) {
+          throw new Error('Failed to fetch members');
+        }
+  
+        const data = response.data;
+  
+        dispatch(setMembers(data)); // Assuming setMembers is your action for setting members
+  
+        return data; // Return the data if needed
+      } catch (error) {
+        return rejectWithValue(error.message); // Handle error
+      }
     }
-
-    return response.data; // レスポンスデータを返す
-});
-
+  );
+  
 const memberSlice = createSlice({
     name: 'members',
     initialState: [],

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -35,7 +35,7 @@ Route::put('/api/members/{id}', [MemberController::class, 'update']);
 
 
 use App\Http\Controllers\FlowstepController;
-Route::get('/api/flowsteps', [FlowstepController::class, 'index']);
+Route::get('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class, 'index']);
 Route::post('/api/flowsteps', [FlowstepController::class, 'store']);
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -36,7 +36,7 @@ Route::put('/api/members/{id}', [MemberController::class, 'update']);
 
 use App\Http\Controllers\FlowstepController;
 Route::get('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class, 'index']);
-Route::post('/api/flowsteps', [FlowstepController::class, 'store']);
+Route::post('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class, 'store']);
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);
 Route::put('/api/flowsteps/{id}', [FlowStepController::class, 'update']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -27,9 +27,8 @@ Route::middleware('auth')->group(function () {
 require __DIR__.'/auth.php';
 
 use App\Http\Controllers\MemberController;
-
-Route::get('/api/members', [MemberController::class, 'index']);
-Route::post('/api/members', [MemberController::class, 'store']);
+Route::get('/api/workflows/{workflowId}/members', [MemberController::class, 'index']);
+Route::post('/api/workflows/{workflowId}/members', [MemberController::class, 'store']);
 Route::post('/api/save-order', [MemberController::class, 'saveOrder']);
 Route::delete('/api/members/{id}', [MemberController::class, 'destroy']);
 Route::put('/api/members/{id}', [MemberController::class, 'update']);
@@ -48,5 +47,15 @@ Route::post('/api/assign-flowstep', [FlowstepMemberController::class, 'store']);
 
 
 use App\Http\Controllers\MatrixFlowController;
+Route::get('/create-matrixflow/{workflowId}', [MatrixFlowController::class, 'renderCreateMatrixFlowPage'])->name('matrixflow.create');
+Route::get('/new-matrixflow', [MatrixFlowController::class, 'renderNewMatrixFlowPage'])->name('matrixflow.new');
+Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'renderCreateMatrixFlowPageforGuest'])->name('guest.matrixflow.create');
+
+use App\Http\Controllers\WorkflowController;
+Route::post('/api/workflow', [WorkflowController::class, 'create'])->name('workflow.create');
+Route::post('/api/workflows', [MatrixFlowController::class, 'store']);
+Route::get('/new-matrixflow', [MatrixFlowController::class, 'renderNewMatrixFlowPage'])->name('matrixflow.new');
 Route::get('/create-matrixflow', [MatrixFlowController::class, 'renderCreateMatrixFlowPage'])->name('matrixflow.create');
 Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'renderCreateMatrixFlowPageforGuest'])->name('guest.matrixflow.create');
+
+


### PR DESCRIPTION
## GitHub Issue Ticket
- close #95 
- close #96 

## やった事
`このプルリクエストにて何をしたのか？`
WorkflowモデルとMemberモデル / Flowstepモデルの紐付け
 - Laravel 
   - エンドポイント変更
     - /api/members → /api/workflows/{workflowid}/members     
     - /api/flowsteps → /api/workflows/{workflowid}/flowsteps     
 - React
   - Laravelのapiの変更に伴うRedux Sliceの変更
   - workflowIdをuseParamsでコンポーネントに渡す

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
ユーザーが1つのフローしか作成できなかったため。
様々なフローを作成できる機能があるのが望ましい。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
