### PR TITLE
Debug_2024.10.25.05.47_RouterとInertiaの競合を解消

### DIFF
--- a/src/app/Http/Controllers/MatrixFlowController.php
+++ b/src/app/Http/Controllers/MatrixFlowController.php
@@ -16,14 +16,13 @@ class MatrixFlowController extends Controller
         ]);
     }
 
-    public function renderCreateMatrixFlowPage()
+    public function renderCreateMatrixFlowPage($workflowId)
     {
-        // Inertia::render を使ってフロントエンドにデータとページを送る
         return Inertia::render('CreateMatrixFlowPage', [
-            'flowData' => 'Sample data for the matrix flow',
+            'workflowId' => $workflowId,
         ]);
     }
-    
+        
     public function renderCreateMatrixFlowPageforGuest()
     {
         // Inertia::render を使ってフロントエンドにデータとページを送る

--- a/src/app/Http/Controllers/WorkflowController.php
+++ b/src/app/Http/Controllers/WorkflowController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Workflow;
+use Illuminate\Http\Request;
+
+class WorkflowController extends Controller
+{
+    // 新しいワークフローを作成するメソッド
+    public function store(Request $request)
+    {
+        // バリデーション (名前フィールドが必須など)
+        $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        // ワークフローを作成
+        $workflow = Workflow::create([
+            'name' => $request->input('name'),
+        ]);
+
+        // 作成したワークフローのIDを返す
+        return response()->json(['id' => $workflow->id], 201);
+    }
+}

--- a/src/app/Models/WorkFlow.php
+++ b/src/app/Models/WorkFlow.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Workflow extends Model
 {
+    use HasFactory;
+
+    // 一括代入可能な属性を指定
+    protected $fillable = ['name'];
+
     public function flowsteps()
     {
         return $this->belongsToMany(Flowstep::class);

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,14 +12,18 @@ import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
-const MatrixCol = ({ openModal, flowNumber, onAssignFlowStep, updateFlowStepNumber, member }) => {
+const MatrixCol = ({ openModal, flowNumber, onAssignFlowStep, updateFlowStepNumber, member, workflowId }) => {
     const dispatch = useDispatch();
     const flowsteps = useSelector((state) => state.flowsteps); // Redux ストアから flowsteps を取得
-    const { workflowId } = useParams();
 
     useEffect(() => {
         dispatch(fetchFlowsteps(workflowId)); // コンポーネントがマウントされたときにフローステップを取得
     }, [dispatch, workflowId]);
+
+    useEffect(() => {
+        console.log('workflowId in MatrixRow:', workflowId);
+    }, [workflowId]);
+
 
     const [{ isOver }, drop] = useDrop(() => ({
         accept: 'FLOWSTEP',
@@ -172,7 +175,7 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
     );
 };
 
-const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
+const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflowId }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedMember, setSelectedMember] = useState(null);
     const [selectedStepNumber, setSelectedStepNumber] = useState(null);
@@ -180,7 +183,6 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
     const [orderedMembers, setOrderedMembers] = useState([]); // 行の順序を管理するための状態を追加
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     const dispatch = useDispatch();
-    const { workflowId } = useParams();
 
     // Reduxストアから指定のworkflowIdに関連するメンバーとフローステップを取得
     const members = useSelector((state) => state.members);
@@ -194,7 +196,7 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded }) => {
     }, [dispatch, workflowId]);
 
     useEffect(() => {
-        console.log('workflowId:', workflowId);
+        console.log('workflowId in MatrixView:', workflowId);
     }, [workflowId]);
 
 

--- a/src/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/src/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -37,8 +37,8 @@ export default function AuthenticatedLayout({ header, children }) {
                                     プロフィール
                                 </NavLink>
                                 <NavLink
-                                    href={route('matrixflow.create')} // 新しいルート名
-                                    active={route().current('matrixflow.create')} // アクティブ状態の判定
+                                    href={route('matrixflow.new')} // 新しいルート名
+                                    active={route().current('matrixflow.new')} // アクティブ状態の判定
                                 >
                                     マトリックスフロー作成
                                 </NavLink>

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -2,20 +2,19 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers } from '../store/memberSlice'; 
 import { fetchFlowsteps, assignFlowStep } from '../store/flowstepsSlice'; 
-import { useParams } from 'react-router-dom';
 import MatrixView from '../Components/MatrixView';
 import Document from '../Components/Document';
 import FlashMessage from '../Components/FlashMessage';
 import '../../css/CreateMatrixFlowPage.css';
 import AuthenticatedLayout from '../Layouts/AuthenticatedLayout'; 
 
-const CreateMatrixFlowPage = () => {
+const CreateMatrixFlowPage = (props) => {
     const dispatch = useDispatch();
     const [flowsteps, setFlowsteps] = useState([]);
     const [membersUpdated, setMembersUpdated] = useState(false);
     const [flowstepsUpdated, setFlowstepsUpdated] = useState(false);
     const [flashMessage, setFlashMessage] = useState('');
-    const { workflowId } = useParams();
+    const { workflowId } = props;
 
     const members = useSelector((state) => state.members);
 
@@ -25,19 +24,9 @@ const CreateMatrixFlowPage = () => {
         dispatch(fetchFlowsteps(workflowId)); // workflowIdに基づいてフローステップを取得
     }, [dispatch, workflowId]);
 
-    const handleCreateWorkflow = async () => {
-        try {
-            const response = await fetch('/api/workflows', { method: 'POST' });
-            const data = await response.json();
-            setWorkflowId(data.id); // 新しいワークフローIDを保存
-            setFlashMessage(`Workflow created with ID: ${data.id}`);
-            setTimeout(() => setFlashMessage(''), 5000);
-        } catch (error) {
-            console.error('Error creating workflow:', error);
-            setFlashMessage('Failed to create workflow');
-            setTimeout(() => setFlashMessage(''), 5000);
-        }
-    };
+    useEffect(() => {
+        console.log('workflowId in CreateMatrixFlowPage:', workflowId);
+    }, [workflowId]);
 
     const handleMemberAdded = (member) => {
         const memberName = member.name || 'Unknown Member'; // メンバー名がオブジェクトのプロパティとして存在することを確認
@@ -82,7 +71,6 @@ const CreateMatrixFlowPage = () => {
         <AuthenticatedLayout>
             <div className="welcome-container">
                 <FlashMessage message={flashMessage} />
-                <button onClick={handleCreateWorkflow}>フローを作成する</button>
                 <div className="content-container">
                     <Document />
                     <MatrixView
@@ -91,6 +79,7 @@ const CreateMatrixFlowPage = () => {
                         onAssignFlowStep={handleAssignFlowStep}
                         onMemberAdded={handleMemberAdded}
                         onFlowStepAdded={handleFlowStepAdded}
+                        workflowId={workflowId}
                     />
                 </div>
             </div>

--- a/src/resources/js/Pages/NewMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/NewMatrixFlowPage.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Inertia } from '@inertiajs/inertia'; // Inertia.js をインポート
+import FlashMessage from '../Components/FlashMessage';
+import '../../css/CreateMatrixFlowPage.css';
+import AuthenticatedLayout from '../Layouts/AuthenticatedLayout';
+
+const NewMatrixFlowPage = () => {
+    const [workflowName, setWorkflowName] = useState(''); // ワークフロー名の状態
+    const [workflowId, setWorkflowId] = useState(null);   // 新しいワークフローIDを保存する状態
+    const [flashMessage, setFlashMessage] = useState(''); // フラッシュメッセージ用の状態
+
+    const handleCreateWorkflow = async (event) => {
+        event.preventDefault(); // フォームのデフォルトの送信を防ぐ
+
+        try {
+            // LaravelのCSRFトークンをmetaタグから取得
+            const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    
+            const response = await fetch('/api/workflows', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': token, // CSRFトークンをヘッダーに追加
+                },
+                body: JSON.stringify({ name: workflowName }), // 入力されたワークフロー名を送信
+            });
+            
+            if (!response.ok) {
+                throw new Error('Failed to create workflow');
+            }
+
+            const data = await response.json();
+            setWorkflowId(data.id); // 新しいワークフローIDを保存
+            setFlashMessage(`Workflow created with ID: ${data.id}`);
+            
+            setTimeout(() => {
+                setFlashMessage('');
+                Inertia.visit(`/create-matrixflow/${data.id}`);
+            }, 3000); // 3秒後に遷移
+        } catch (error) {
+            console.error('Error creating workflow:', error);
+            setFlashMessage('Failed to create workflow');
+            setTimeout(() => setFlashMessage(''), 5000);
+        }
+    };
+
+    return (
+        <AuthenticatedLayout>
+            <div className="welcome-container">
+                <FlashMessage message={flashMessage} />
+                <form onSubmit={handleCreateWorkflow}>
+                    <div className="form-group">
+                        <label htmlFor="workflowName">ワークフロー名:</label>
+                        <input
+                            type="text"
+                            id="workflowName"
+                            value={workflowName}
+                            onChange={(e) => setWorkflowName(e.target.value)} // 入力値を状態にセット
+                            required
+                        />
+                    </div>
+                    <button type="submit">フローを作成する</button>
+                </form>
+            </div>
+        </AuthenticatedLayout>
+    );
+};
+
+export default NewMatrixFlowPage;

--- a/src/resources/js/app.jsx
+++ b/src/resources/js/app.jsx
@@ -10,7 +10,7 @@ import { DndProvider } from 'react-dnd'; // react-dnd の DndProvider をイン�
 import { HTML5Backend } from 'react-dnd-html5-backend'; // HTML5Backend をインポート
 import Layout from './Layouts/Layout';
 import { Helmet } from 'react-helmet';
-import { BrowserRouter, Route, Routes } from 'react-router-dom'; // BrowserRouterとRouteをインポート
+
 
 // CSRFトークンを取得する関数（nullチェックを追加）
 const csrfToken = () => {
@@ -24,6 +24,7 @@ axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken();
 
 const appName = import.meta.env.VITE_APP_NAME || 'matrixflow';
 
+
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     resolve: (name) =>
@@ -35,22 +36,21 @@ createInertiaApp({
         const root = createRoot(el);
 
         root.render(
-            <BrowserRouter> {/* BrowserRouterでラップ */}
+            <>
                 <Provider store={store}>
                     <DndProvider backend={HTML5Backend}>
                         <Layout>
                             <Helmet>
                                 <link rel="icon" href="/favicon.ico" type="image/x-icon" />
                             </Helmet>
-                            <Routes> {/* Routesコンポーネントでラップ */}
-                                <Route path="/create-matrixflow/:workflowId" element={<App {...props} />} />
-                                {/* 他のルートを必要に応じて追加 */}
-                            </Routes>
+
+                            <App {...props} />
                         </Layout>
                     </DndProvider>
                 </Provider>
-            </BrowserRouter>
+            </>
         );
+        
     },
     progress: {
         color: '#4B5563',

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -53,9 +53,6 @@ Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'render
 
 use App\Http\Controllers\WorkflowController;
 Route::post('/api/workflow', [WorkflowController::class, 'create'])->name('workflow.create');
-Route::post('/api/workflows', [MatrixFlowController::class, 'store']);
-Route::get('/new-matrixflow', [MatrixFlowController::class, 'renderNewMatrixFlowPage'])->name('matrixflow.new');
-Route::get('/create-matrixflow', [MatrixFlowController::class, 'renderCreateMatrixFlowPage'])->name('matrixflow.create');
-Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'renderCreateMatrixFlowPageforGuest'])->name('guest.matrixflow.create');
+Route::post('/api/workflows', [WorkFlowController::class, 'store']);
 
 


### PR DESCRIPTION
## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
Laravel Inertiaと React Routerの競合を解消
 - Laravel
   - コントローラー上でInertiaを使い、useParamsで渡していたworkflowIdをコンポーネントに渡す 
 - React
   - useParamsを使用していたが不使用化（React Routerを使用するため）

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Laravelのデフォルトのログイン、アカウント登録へのリンクが使用不可となってしまった不具合を解消

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
