### PR TITLE
Debug 2024.10.25.06.41 production環境でworkflowレコードを作成できない

### DIFF
--- a/src/resources/js/Pages/NewMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/NewMatrixFlowPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Inertia } from '@inertiajs/inertia'; // Inertia.js をインポート
+import axios from 'axios'; // Axiosをインポート
 import FlashMessage from '../Components/FlashMessage';
 import '../../css/CreateMatrixFlowPage.css';
 import AuthenticatedLayout from '../Layouts/AuthenticatedLayout';
@@ -15,27 +16,25 @@ const NewMatrixFlowPage = () => {
         try {
             // LaravelのCSRFトークンをmetaタグから取得
             const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-    
-            const response = await fetch('/api/workflows', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': token, // CSRFトークンをヘッダーに追加
-                },
-                body: JSON.stringify({ name: workflowName }), // 入力されたワークフロー名を送信
-            });
-            
-            if (!response.ok) {
-                throw new Error('Failed to create workflow');
+            if (!token) {
+              console.error('CSRF token not found');
             }
 
-            const data = await response.json();
-            setWorkflowId(data.id); // 新しいワークフローIDを保存
-            setFlashMessage(`Workflow created with ID: ${data.id}`);
+            const response = await axios.post('/api/workflows', {
+                name: workflowName // 入力されたワークフロー名を送信
+            }, {
+                headers: {
+                    'X-CSRF-TOKEN': token, // CSRFトークンをヘッダーに追加
+                }
+            });
+
+            setWorkflowId(response.data.id); // 新しいワークフローIDを保存
+            setFlashMessage(`Workflow created with ID: ${response.data.id}`);
             
             setTimeout(() => {
                 setFlashMessage('');
-                Inertia.visit(`/create-matrixflow/${data.id}`);
+                // Inertia.visit(`/create-matrixflow/${response.data.id}`);
+                window.location.href = `/create-matrixflow/${response.data.id}`;
             }, 3000); // 3秒後に遷移
         } catch (error) {
             console.error('Error creating workflow:', error);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -52,7 +52,6 @@ Route::get('/new-matrixflow', [MatrixFlowController::class, 'renderNewMatrixFlow
 Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'renderCreateMatrixFlowPageforGuest'])->name('guest.matrixflow.create');
 
 use App\Http\Controllers\WorkflowController;
-Route::post('/api/workflow', [WorkflowController::class, 'create'])->name('workflow.create');
-Route::post('/api/workflows', [WorkFlowController::class, 'store']);
+Route::post('/api/workflows', [WorkFlowController::class, 'store'])->name('workflow.create');
 
 


### PR DESCRIPTION
## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
Workflow作成アクション周りを修正
 - ルーティングの重複を解消
 - WorkFlow作成のアクションをaxios化

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Heroku本番環境で409エラー発生によりWorkflowレコードが作成できない不具合発生

開発環境ではWorkflowレコードの作成自体はできるが下記エラーが発生していたため解消した
```
NewMatrixFlowPage.jsx:36 
 GET http://localhost/create-matrixflow/30 409 (Conflict)
```
## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
