### PR TITLE
Feature 2024.10.27.19.29 step間のチェック項目を追加できるように実装する #105

### DIFF
--- a/src/app/Http/Controllers/CheckitemController.php
+++ b/src/app/Http/Controllers/CheckitemController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Checkitem;
+use Illuminate\Http\Request;
+
+class CheckitemController extends Controller
+{
+    // CheckListに関連するCheckItemsの取得
+    public function index($workflowId, $checklistId)
+    {
+        $checkItems = CheckItem::where('checklist_id', $checklistId)->get();
+        return response()->json($checkItems);
+    }
+
+    // CheckItemの作成
+    public function store(Request $request, $workflowId, $checklistId)
+    {
+        $checkItem = new CheckItem();
+        $checkItem->checklist_id = $checklistId;
+        $checkItem->name = $request->input('name');
+        $checkItem->save();
+
+        return response()->json($checkItem, 201);
+    }
+
+    // CheckItemの詳細取得
+    public function show($workflowId, $checklistId, $id)
+    {
+        $checkItem = CheckItem::where('checklist_id', $checklistId)->findOrFail($id);
+        return response()->json($checkItem);
+    }
+
+    // CheckItemの更新
+    public function update(Request $request, $workflowId, $checklistId, $id)
+    {
+        $checkItem = CheckItem::where('checklist_id', $checklistId)->findOrFail($id);
+        $checkItem->name = $request->input('name');
+        $checkItem->save();
+
+        return response()->json($checkItem);
+    }
+
+    // CheckItemの削除
+    public function destroy($workflowId, $checklistId, $id)
+    {
+        $checkItem = CheckItem::where('checklist_id', $checklistId)->findOrFail($id);
+        $checkItem->delete();
+
+        return response()->json(['message' => 'CheckItem deleted successfully']);
+    }
+}

--- a/src/app/Http/Controllers/ChecklistController.php
+++ b/src/app/Http/Controllers/ChecklistController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Checklist;
+use Illuminate\Http\Request;
+
+class ChecklistController extends Controller
+{
+    // 指定したworkflowに関連するCheckListの取得
+    public function index($workflowId)
+    {
+        $checklists = CheckList::where('workflow_id', $workflowId)->get();
+        return response()->json($checklists);
+    }
+
+    public function store(Request $request, $workflowId)
+    {
+        // リクエストからデータを取得
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'flownumber_for_checklist' => 'required|integer',
+        ]);
+    
+        $checklist = new CheckList();
+        $checklist->workflow_id = $workflowId;
+        $checklist->name = $data['name']; // 修正: $dataからnameを取得
+        $checklist->flownumber_for_checklist = $data['flownumber_for_checklist']; // 修正: $dataからflownumber_for_checklistを取得
+        $checklist->save();
+    
+        return response()->json($checklist, 201);
+    }
+    
+    // CheckListの詳細取得
+    public function show($workflowId, $id)
+    {
+        $checklist = CheckList::where('workflow_id', $workflowId)->findOrFail($id);
+        return response()->json($checklist);
+    }
+
+    // CheckListの更新
+    public function update(Request $request, $workflowId, $id)
+    {
+        $checklist = CheckList::where('workflow_id', $workflowId)->findOrFail($id);
+        $checklist->name = $request->input('name');
+        $checklist->flownumber_for_checklist = $data['flownumber_for_checklist'];
+        $checklist->save();
+
+        return response()->json($checklist);
+    }
+
+    // CheckListの削除
+    public function destroy($workflowId, $id)
+    {
+        $checklist = CheckList::where('workflow_id', $workflowId)->findOrFail($id);
+        $checklist->delete();
+
+        return response()->json(['message' => 'CheckList deleted successfully']);
+    }
+}

--- a/src/app/Models/CheckItem.php
+++ b/src/app/Models/CheckItem.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CheckItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['checklist_id', 'check_content', 'member_id'];
+
+    public function checkLists()
+    {
+        return $this->belongsToMany(CheckList::class, 'checklist_checkitem');
+    }
+}

--- a/src/app/Models/CheckList.php
+++ b/src/app/Models/CheckList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CheckList extends Model
+{
+    use HasFactory;
+
+    protected $table = 'checklists';
+
+    protected $fillable = ['workflow_id', 'flownumber_for_checklist', 'name'];
+
+    public function checkItems()
+    {
+        return $this->belongsToMany(CheckItem::class, 'checklist_checkitem');
+    }
+}

--- a/src/database/migrations/2024_10_27_140111_create_checklists_table.php
+++ b/src/database/migrations/2024_10_27_140111_create_checklists_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChecklistsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('checklists', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('workflow_id')->nullable(); // workflow_idカラム
+            $table->unsignedInteger('flownumber_for_checklist');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('checklists');
+    }
+}

--- a/src/database/migrations/2024_10_27_140139_create_checkitems_table.php
+++ b/src/database/migrations/2024_10_27_140139_create_checkitems_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCheckitemsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('checkitems', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('checklist_id'); // checklist_idカラム
+            $table->string('check_content');
+            $table->unsignedBigInteger('member_id')->nullable(); // member_idカラム
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('checkitems');
+    }
+}

--- a/src/database/migrations/2024_10_27_140158_create_checklist_checkitem_table.php
+++ b/src/database/migrations/2024_10_27_140158_create_checklist_checkitem_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChecklistCheckitemTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('checklist_checkitem', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('checklist_id')->constrained()->onDelete('cascade');
+            $table->foreignId('checkitem_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('checklist_checkitem');
+    }
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -12,6 +12,7 @@
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1",
                 "react-helmet": "^6.1.0",
+                "react-modal": "^3.16.1",
                 "react-redux": "^9.1.2",
                 "react-router-dom": "^6.27.0",
                 "vite": "^5.4.8"
@@ -1920,6 +1921,11 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/exenv": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+            "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2925,6 +2931,29 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
+        "node_modules/react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "node_modules/react-modal": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+            "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+            }
+        },
         "node_modules/react-redux": {
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
@@ -3562,6 +3591,14 @@
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/which": {

--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,7 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-helmet": "^6.1.0",
+        "react-modal": "^3.16.1",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.27.0",
         "vite": "^5.4.8"

--- a/src/resources/css/AddCheckListForm.css
+++ b/src/resources/css/AddCheckListForm.css
@@ -1,0 +1,52 @@
+.form-container {
+  background-color: #f9f9f9;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  margin: 10px 0;
+}
+
+.AddCheckListForm-title {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.AddCheckListForm-title-icon {
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.AddCheckListForm-checklist-input {
+  margin-left: 20px;
+}
+
+.form-container label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+
+.form-container input[type="text"],
+.form-container input[type="number"],
+.form-container select {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 15px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.form-container button {
+  background-color: #4CAF50;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.form-container button:hover {
+  background-color: #45a049;
+}

--- a/src/resources/css/AddCheckListForm.css
+++ b/src/resources/css/AddCheckListForm.css
@@ -6,6 +6,11 @@
   margin: 10px 0;
 }
 
+.AddCheckListForm-title-container {
+  display: flex;
+  text-align: center;
+}
+
 .AddCheckListForm-title {
   text-align: center;
   font-weight: bold;

--- a/src/resources/css/CheckListModal.css
+++ b/src/resources/css/CheckListModal.css
@@ -1,0 +1,31 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000; /* 他の要素の上に表示する */
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}

--- a/src/resources/css/CheckListModalContent.css
+++ b/src/resources/css/CheckListModalContent.css
@@ -1,0 +1,39 @@
+.checklist-container {
+  list-style-type: none; /* リストのデフォルトスタイルを無効化 */
+  padding: 0; /* パディングをリセット */
+}
+
+.checklists {
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 16px; /* 縦に並べるために下にマージンを追加 */
+  transition: transform 0.2s;
+}
+
+.checklists:hover {
+  background-color: aliceblue;
+  cursor: pointer; /* カーソルをポインターに */
+}
+
+.error-message {
+  color: red; /* エラーメッセージの色 */
+  margin-top: 8px; /* 上部のマージン */
+}
+
+.form-row {
+  display: flex;
+  align-items: center; /* 垂直方向の中央揃え */
+}
+
+.form-row input {
+  margin-right: 10px; /* アイコンとのスペースを調整 */
+}
+
+.form-row button {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}

--- a/src/resources/css/ModalforAddCheckListForm.css
+++ b/src/resources/css/ModalforAddCheckListForm.css
@@ -1,0 +1,31 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000; /* 他の要素の上に表示する */
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}

--- a/src/resources/js/Components/AddCheckListForm.jsx
+++ b/src/resources/js/Components/AddCheckListForm.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { fetchFlowsteps } from '../store/flowstepsSlice';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types'; // PropTypesをインポート
+
+import '../../css/AddCheckListForm.css';
+
+const AddCheckListForm = ({
+    members,
+    member = null,
+    stepNumber = '',
+    nextStepNumber,
+    workflowId,
+    checkListsByColumn,
+    setCheckListsByColumn,
+}) => {
+    const [checkItemName, setCheckItemName] = useState('');
+    const [selectedMembers, setSelectedMembers] = useState(member ? [member.id] : []);
+    const [selectedStepNumber, setSelectedStepNumber] = useState(stepNumber);
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (member) {
+            setSelectedMembers([member.id]);
+        }
+        if (stepNumber) {
+            setSelectedStepNumber(stepNumber);
+        }
+    }, [member, stepNumber]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (!checkItemName || selectedMembers.length === 0) {
+            return;
+        }
+
+        const newCheckItem = {
+            id: Date.now(),
+            name: checkItemName,
+            check_items: selectedMembers.map(memberId => ({
+                id: Date.now(),
+                check_content: "⚪︎⚪︎する",
+                member_id: memberId
+            })),
+        };
+
+        setCheckListsByColumn((prev) => ({
+            ...prev,
+            [selectedStepNumber]: prev[selectedStepNumber]
+                ? [...prev[selectedStepNumber], newCheckItem]
+                : [newCheckItem]
+        }));
+
+        setCheckItemName('');
+        setSelectedMembers([]);
+        console.log('Check item added:', newCheckItem);
+        dispatch(fetchFlowsteps(workflowId));
+    };
+
+    const handleMemberChange = (e) => {
+        const options = e.target.options;
+        const value = [];
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected) {
+                value.push(options[i].value);
+            }
+        }
+        setSelectedMembers(value);
+    };
+
+    const filteredMembers = members.filter((m) =>
+        m.name.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    return (
+        <>
+          <div>
+              <form className="form-container" onSubmit={handleSubmit}>
+                  <div className="AddCheckListForm-title">
+                    <FontAwesomeIcon icon={faClipboardCheck} className="AddCheckListForm-title-icon" />
+                    チェックリストを追加
+                    <FontAwesomeIcon icon={faClipboardCheck} className="AddCheckListForm-title-icon" />
+                  </div>
+                  <div>
+                      <label>チェックリスト名:</label>
+                      <input
+                          type="text"
+                          value={checkItemName}
+                          onChange={(e) => setCheckItemName(e.target.value)}
+                          required
+                          placeholder="チェックリストの名前を入力"
+                          />
+                  </div>
+                  <div className="AddCheckListForm-checklist-input">
+                    <label>チェックリストの項目:</label>
+                    <ul>
+                      <li>
+                        <input
+                            type="text"
+                            value={checkItemName}
+                            onChange={(e) => setCheckItemName(e.target.value)}
+                            required
+                            placeholder="チェックリストの項目を入力"
+                        />
+                      </li>
+                    </ul>
+                  </div>
+                  <button type="submit">チェックリストを追加</button>
+              </form>
+          </div>
+        </>
+    );
+};
+
+AddCheckListForm.propTypes = {
+    members: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            name: PropTypes.string.isRequired,
+        })
+    ),
+    member: PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+    }),
+    stepNumber: PropTypes.string,
+    nextStepNumber: PropTypes.string,
+    workflowId: PropTypes.number.isRequired,
+    checkListsByColumn: PropTypes.object.isRequired,
+    setCheckListsByColumn: PropTypes.func.isRequired,
+};
+
+export default AddCheckListForm;

--- a/src/resources/js/Components/AddCheckListForm.jsx
+++ b/src/resources/js/Components/AddCheckListForm.jsx
@@ -1,65 +1,65 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { fetchFlowsteps } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
-import PropTypes from 'prop-types'; // PropTypesをインポート
+import { add } from '../store/checklistSlice'; // Adjust the import path as needed
+import '../../css/AddFlowStepForm.css';
 
-import '../../css/AddCheckListForm.css';
+const AddFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {
+    const [name, setName] = useState(''); 
+    const [error, setError] = useState(null);
+    const [flowNumber, setFlowNumber] = useState(stepNumber); 
+    const [selectedMembers, setSelectedMembers] = useState(member ? [member.id] : []); 
+    const [selectedStepNumber, setSelectedStepNumber] = useState(stepNumber); 
+    const [searchTerm, setSearchTerm] = useState(''); 
 
-const AddCheckListForm = ({
-    members,
-    member = null,
-    stepNumber = '',
-    nextStepNumber,
-    workflowId,
-    checkListsByColumn,
-    setCheckListsByColumn,
-}) => {
-    const [checkItemName, setCheckItemName] = useState('');
-    const [selectedMembers, setSelectedMembers] = useState(member ? [member.id] : []);
-    const [selectedStepNumber, setSelectedStepNumber] = useState(stepNumber);
-    const [searchTerm, setSearchTerm] = useState('');
-
-    const dispatch = useDispatch();
+    const dispatch = useDispatch(); // Get the dispatch function
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
     useEffect(() => {
         if (member) {
             setSelectedMembers([member.id]);
         }
         if (stepNumber) {
+            setFlowNumber(stepNumber);
             setSelectedStepNumber(stepNumber);
         }
     }, [member, stepNumber]);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-
-        if (!checkItemName || selectedMembers.length === 0) {
-            return;
-        }
-
-        const newCheckItem = {
-            id: Date.now(),
-            name: checkItemName,
-            check_items: selectedMembers.map(memberId => ({
-                id: Date.now(),
-                check_content: "⚪︎⚪︎する",
-                member_id: memberId
-            })),
+        setError(null);
+        
+        // selectedStepNumberの値を確認
+        console.log('Selected Step Number before submitting:', selectedStepNumber);
+    
+        // チェックリストのデータを構成
+        const checklistData = {
+            name: name,
+            flownumber_for_checklist: selectedStepNumber, // STEP番号を使用
         };
-
-        setCheckListsByColumn((prev) => ({
-            ...prev,
-            [selectedStepNumber]: prev[selectedStepNumber]
-                ? [...prev[selectedStepNumber], newCheckItem]
-                : [newCheckItem]
-        }));
-
-        setCheckItemName('');
-        setSelectedMembers([]);
-        console.log('Check item added:', newCheckItem);
-        dispatch(fetchFlowsteps(workflowId));
+    
+        console.log('Sending checklist data:', checklistData, 'to workflowId:', workflowId); // 送信されるデータをログ
+    
+        try {
+            // Reduxアクションをディスパッチ
+            const action = await dispatch(addCheckList({ workflowId, checklist: checklistData })).unwrap();
+            setName(''); // 入力をクリア
+            console.log('Checklist added:', action); // 成功した場合の処理
+            // 必要に応じて、チェックリストを再取得する
+            dispatch(fetchCheckLists(workflowId)); // チェックリストを再取得
+        } catch (error) {
+            if (error.response && error.response.status === 422) {
+                console.error('Validation errors:', error.response.data.errors);
+            } else {
+                console.error('Error adding Checklist:', error);
+            }
+        }
+    };
+    
+    
+    const handleDelete = (id) => {
+        dispatch(deleteFlowstepAsync(id));
     };
 
     const handleMemberChange = (e) => {
@@ -73,66 +73,80 @@ const AddCheckListForm = ({
         setSelectedMembers(value);
     };
 
-    const filteredMembers = members.filter((m) =>
+    const handleStepChange = (e) => {
+        setSelectedStepNumber(e.target.value);
+    };
+
+    const filteredMembers = members.filter((m) => 
         m.name.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
     return (
-        <>
-          <div>
-              <form className="form-container" onSubmit={handleSubmit}>
-                  <div className="AddCheckListForm-title">
+        <div>
+            <form className="form-container" onSubmit={handleSubmit}>
+                <div className="AddCheckListForm-title-container">
                     <FontAwesomeIcon icon={faClipboardCheck} className="AddCheckListForm-title-icon" />
-                    チェックリストを追加
-                    <FontAwesomeIcon icon={faClipboardCheck} className="AddCheckListForm-title-icon" />
-                  </div>
-                  <div>
-                      <label>チェックリスト名:</label>
-                      <input
-                          type="text"
-                          value={checkItemName}
-                          onChange={(e) => setCheckItemName(e.target.value)}
-                          required
-                          placeholder="チェックリストの名前を入力"
-                          />
-                  </div>
-                  <div className="AddCheckListForm-checklist-input">
-                    <label>チェックリストの項目:</label>
-                    <ul>
-                      <li>
-                        <input
-                            type="text"
-                            value={checkItemName}
-                            onChange={(e) => setCheckItemName(e.target.value)}
-                            required
-                            placeholder="チェックリストの項目を入力"
-                        />
-                      </li>
-                    </ul>
-                  </div>
-                  <button type="submit">チェックリストを追加</button>
-              </form>
-          </div>
-        </>
+                    <div className="AddCheckListForm-title">
+                        チェックリストを作成する
+                    </div>
+                    <FontAwesomeIcon icon={faClipboardCheck}  className="AddCheckListForm-title-icon" />
+                </div>
+                <div>
+                    <label>フローステップ名:</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)} 
+                        required
+                        placeholder="担当者がフローとして行うことを入力しましょう"
+                    />
+                </div>
+                <div>
+                    <label>ステップNo.:</label>
+                    <select
+                        value={selectedStepNumber}
+                        onChange={handleStepChange}
+                        required
+                    >
+                        {Array.from({ length: nextStepNumber }, (_, index) => (
+                            <option key={index + 1} value={index + 1}>
+                                STEP {index + 1}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label>担当者を検索:</label>
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder="担当者を名前検索できます"
+                    />
+                </div>
+                <div>
+                    <label>担当者を選択:</label>
+                    <select
+                        multiple
+                        value={selectedMembers}
+                        onChange={handleMemberChange}
+                        required
+                    >
+                        {filteredMembers.length > 0 ? (
+                            filteredMembers.map((m) => (
+                                <option key={m.id} value={m.id}>
+                                    {m.name}
+                                </option>
+                            ))
+                        ) : (
+                            <option disabled>No members available</option>
+                        )}
+                    </select>
+                </div>
+                <button type="submit">フローステップを追加</button>
+            </form>
+        </div>
     );
 };
 
-AddCheckListForm.propTypes = {
-    members: PropTypes.arrayOf(
-        PropTypes.shape({
-            id: PropTypes.number.isRequired,
-            name: PropTypes.string.isRequired,
-        })
-    ),
-    member: PropTypes.shape({
-        id: PropTypes.number,
-        name: PropTypes.string,
-    }),
-    stepNumber: PropTypes.string,
-    nextStepNumber: PropTypes.string,
-    workflowId: PropTypes.number.isRequired,
-    checkListsByColumn: PropTypes.object.isRequired,
-    setCheckListsByColumn: PropTypes.func.isRequired,
-};
-
-export default AddCheckListForm;
+export default AddFlowStepForm;

--- a/src/resources/js/Components/AddCheckListForm.jsx
+++ b/src/resources/js/Components/AddCheckListForm.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
-import { add } from '../store/checklistSlice'; // Adjust the import path as needed
+import { fetchCheckLists, addCheckList } from '../store/checklistSlice'; // Adjust the import path as needed
 import '../../css/AddFlowStepForm.css';
 
 const AddFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {

--- a/src/resources/js/Components/AddCheckListForm.jsx
+++ b/src/resources/js/Components/AddCheckListForm.jsx
@@ -85,11 +85,15 @@ const AddFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = nu
         <div>
             <form className="form-container" onSubmit={handleSubmit}>
                 <div className="AddCheckListForm-title-container">
-                    <FontAwesomeIcon icon={faClipboardCheck} className="AddCheckListForm-title-icon" />
+                    <div className="AddCheckListForm-title-icon">
+                        <FontAwesomeIcon icon={faClipboardCheck} />
+                    </div>
                     <div className="AddCheckListForm-title">
                         チェックリストを作成する
                     </div>
-                    <FontAwesomeIcon icon={faClipboardCheck}  className="AddCheckListForm-title-icon" />
+                    <div className="AddCheckListForm-title-icon">
+                        <FontAwesomeIcon icon={faClipboardCheck} />
+                    </div>
                 </div>
                 <div>
                     <label>フローステップ名:</label>

--- a/src/resources/js/Components/AddCheckListForm.jsx
+++ b/src/resources/js/Components/AddCheckListForm.jsx
@@ -5,7 +5,7 @@ import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
 import { fetchCheckLists, addCheckList } from '../store/checklistSlice'; // Adjust the import path as needed
 import '../../css/AddFlowStepForm.css';
 
-const AddFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {
+const AddCheckListForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {
     const [name, setName] = useState(''); 
     const [error, setError] = useState(null);
     const [flowNumber, setFlowNumber] = useState(stepNumber); 
@@ -153,4 +153,4 @@ const AddFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = nu
     );
 };
 
-export default AddFlowStepForm;
+export default AddCheckListForm;

--- a/src/resources/js/Components/CheckListModal.jsx
+++ b/src/resources/js/Components/CheckListModal.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import '../../css/CheckListModal.css';
+
+const CheckListModal = ({ isOpen, onClose, children }) => {
+    if (!isOpen) return null; // モーダルが開いていない場合は何も表示しない
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={onClose}>×</button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default CheckListModal;

--- a/src/resources/js/Components/CheckListModalContent.jsx
+++ b/src/resources/js/Components/CheckListModalContent.jsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
+import { fetchCheckLists, addCheckList, selectCheckListsByFlowNumber } from '../store/checklistSlice'; // Adjust the import path as needed
+import '../../css/CheckListModalContent.css';
+
+const CheckListModalContent = ({ workflowId, flowNumber, checkListsForFlowNumber }) => {
+    const [name, setName] = useState('');
+    const [error, setError] = useState(null);
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(fetchCheckLists(workflowId)); // フェッチする必要があれば
+    }, [dispatch, workflowId]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError(null);
+
+        const checklistData = {
+            name,
+            flownumber_for_checklist: flowNumber, // flowNumberを使用
+        };
+
+        try {
+            await dispatch(addCheckList({ workflowId, checklist: checklistData })).unwrap();
+            setName(''); // 入力をクリア
+            dispatch(fetchCheckLists(workflowId)); // チェックリストを再取得
+        } catch (error) {
+            if (error.response && error.response.status === 422) {
+                console.error('Validation errors:', error.response.data.errors);
+                setError('Validation error occurred.');
+            } else {
+                console.error('Error adding Checklist:', error);
+                setError('An error occurred while adding the checklist.');
+            }
+        }
+    };
+
+    return (
+        <div>
+            <form className="form-container" onSubmit={handleSubmit}>
+                <div className="AddCheckListForm-title-container">
+                    <div className="AddCheckListForm-title-icon">
+                        <FontAwesomeIcon icon={faClipboardCheck} />
+                    </div>
+                    <div className="AddCheckListForm-title">
+                        チェックリストを作成する
+                    </div>
+                    <div className="AddCheckListForm-title-icon">
+                        <FontAwesomeIcon icon={faClipboardCheck} />
+                    </div>
+                </div>
+                <div>
+                    <label>チェックリスト名:</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)} 
+                        required
+                        placeholder="チェックリストの名前を入力してください"
+                    />
+                </div>
+                {error && <div className="error-message">{error}</div>}
+                <button type="submit">チェックリストを追加</button>
+            </form>
+
+            <h3>既存のチェックリスト</h3>
+            <ul className="checklist-container">
+                {checkListsForFlowNumber.map((checklist) => (
+                    <li key={checklist.id} className="checklists">{checklist.name}</li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default CheckListModalContent;

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -11,30 +11,57 @@ import AddFlowStepForm from '../Components/AddFlowStepForm';
 import AddCheckListForm from '../Components/AddCheckListForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
 import ModalforAddCheckListForm from '../Components/ModalforAddCheckListForm';
+import CheckListModal from '../Components/CheckListModal';
+import CheckListModalContent from '../Components/CheckListModalContent';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
-const CheckItemColumn = ({ flowNumber, onAddCheckItem, openAddCheckListModal, workflowId }) => {
+const CheckItemColumn = ({ member, flowNumber, openAddCheckListModal, workflowId }) => {
     const checkListsFromStore = useSelector(selectCheckListsByColumn);
-
-    // flowNumberに基づいてチェックリストを取得
     const checkListsForFlowNumber = checkListsFromStore[flowNumber] || [];
+    
+    const [selectedCheckList, setSelectedCheckList] = useState(null); // 選択されたチェックリストを保持する状態
+    const [isModalOpen, setIsModalOpen] = useState(false); // モーダルのオープン状態を管理
 
-    // flowNumberとworkflowIdの両方に一致するチェックリストが1つ以上存在するか確認
     const hasCheckList = checkListsForFlowNumber.some(checklist => checklist.workflow_id === workflowId);
     console.log("hasCheckList:", hasCheckList);
+
+    const handleCheckListClick = (checklist) => {
+        setSelectedCheckList(checklist); // 選択されたチェックリストを設定
+        setIsModalOpen(true); // モーダルを開く
+    };
+
+    const closeModal = () => {
+        setIsModalOpen(false); // モーダルを閉じる
+        setSelectedCheckList(null); // 選択をリセット
+    };
 
     return (
         <td className="matrix-check-item-column">
             {hasCheckList ? (
-                <div className="check-item" onClick={() => openAddCheckListModal()}>
+                <div className="check-item" onClick={() => handleCheckListClick(checkListsForFlowNumber[0])}>
                     <FontAwesomeIcon icon={faClipboardCheck} /> {/* 1つだけ表示 */}
                 </div>
             ) : (
-                <div className="check-item" onClick={() => openAddCheckListModal()}>
+                <div className="check-item" onClick={openAddCheckListModal}>
                     <FontAwesomeIcon icon={faPlus} /> {/* チェック項目追加 */}
                 </div>
+            )}
+
+            {/* モーダルの表示 */}
+            {isModalOpen && (
+                <CheckListModal 
+                    isOpen={isModalOpen} 
+                    onClose={closeModal} 
+                    checkList={selectedCheckList} // 選択されたチェックリストをモーダルに渡す
+                >
+                    <CheckListModalContent
+                      workflowId={workflowId}
+                      flowNumber={flowNumber}
+                      checkListsForFlowNumber={checkListsForFlowNumber}
+                    />
+                </CheckListModal >
             )}
         </td>
     );
@@ -242,6 +269,7 @@ const MatrixRow = ({
                         />
                         {flowNumber < maxFlowNumber && (
                             <CheckItemColumn
+                                member={member}
                                 flowNumber={flowNumber}
                                 checkItems={checkItems}
                                 onAddCheckItem={() => handleAddCheckItem(flowNumber)}

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUser, faSquarePlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBarrier, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faUser, faSquarePlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBarrier, faPlus, faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
 import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
@@ -12,25 +12,23 @@ import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import '../../css/MatrixView.css';
 
-const CheckItemColumn = ({ flowNumber }) => {
-    // 状態やプロップスからチェック項目を取得するロジックを追加
-    const checkItems = []; // チェック項目の配列を取得
-
+const CheckItemColumn = ({ flowNumber, checkItems, onAddCheckItem }) => {
     return (
         <td className="matrix-check-item-column">
             {checkItems.length > 0 ? (
-                checkItems.map((item, index) => (
-                    <div key={index} className="check-item">
-                        {item.checked ? '✔️' : '❌'}
+                checkItems.map((item) => (
+                    <div key={item.id} className="check-item">
+                        <FontAwesomeIcon icon={faClipboardCheck} />
                     </div>
                 ))
             ) : (
-                <div className="check-item"><FontAwesomeIcon icon={faPlus} /></div> // チェック項目がない場合の表示
+                <div className="check-item" onClick={onAddCheckItem}>
+                    <FontAwesomeIcon icon={faPlus} /> {/* チェック項目追加 */}
+                </div>
             )}
         </td>
     );
 };
-
 
 const MatrixCol = ({ openModal, flowNumber, onAssignFlowStep, updateFlowStepNumber, member, workflowId }) => {
     const dispatch = useDispatch();
@@ -101,6 +99,21 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [newName, setNewName] = useState(member.name); // Set initial value to member.name
+
+    // const [checkItemsByColumn, setCheckItemsByColumn] = useState({}); // 各列ごとのcheckItemsを保持
+    const [checkItemsByColumn, setCheckItemsByColumn] = useState({
+        1: [{ id: 1, name: 'Check Item 1-1' }],
+        2: [{ id: 3, name: 'Check Item 2-1' }],
+        3: [{ id: 4, name: 'Check Item 3-1' }]
+    }); // 各列ごとに初期値としてチェック項目を追加
+
+    const handleAddCheckItem = (flowNumber) => {
+        const newCheckItem = { id: 1, name: 'New Check Item ${flowNumber}' }; // 新しいチェック項目を定義
+        setCheckItemsByColumn((prev) => ({
+            ...prev,
+            [flowNumber]: [...(prev[flowNumber] || []), newCheckItem], // flowNumberに応じて項目を追加
+        }));
+    };
 
     const [{ isDragging }, drag] = useDrag(() => ({
         type: 'ROW',
@@ -187,7 +200,15 @@ const MatrixRow = ({ member, onAssignFlowStep, openModal, maxFlowNumber, index, 
                         updateFlowStepNumber={updateFlowStepNumber}
                         workflowId={workflowId}
                     />
-                    {i < maxFlowNumber - 1 && <CheckItemColumn flowNumber={i + 1} />} {/* チェック項目列を追加 */}
+                    {i < maxFlowNumber - 1 &&
+                     (
+                        <CheckItemColumn
+                            flowNumber={i + 1}
+                            checkItems={checkItemsByColumn[i + 1] || []} // 各列ごとのチェック項目を渡す
+                            onAddCheckItem={() => handleAddCheckItem(i + 1)}
+                        />
+                    )
+                    } {/* チェック項目列を追加 */}
                 </React.Fragment>
             ))}
 

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -541,7 +541,6 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                         member={selectedMember}
                         stepNumber={selectedStepNumber}
                         nextStepNumber={maxFlowNumber + 1}
-                        isOpen={isModalforAddCheckListFormOpen} 
                         onClose={closeAddCheckListModal}
                         onFlowStepAdded={onFlowStepAdded}
                         workflowId={workflowId}

--- a/src/resources/js/Components/ModalforAddCheckListForm.jsx
+++ b/src/resources/js/Components/ModalforAddCheckListForm.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import '../../css/ModalforAddCheckListForm.css';
+
+const ModalforAddCheckListForm = ({ isOpen, onClose, children }) => {
+    if (!isOpen) return null; // モーダルが開いていない場合は何も表示しない
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={onClose}>×</button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default ModalforAddCheckListForm;

--- a/src/resources/js/Pages/Dashboard.jsx
+++ b/src/resources/js/Pages/Dashboard.jsx
@@ -3,13 +3,7 @@ import { Head } from '@inertiajs/react';
 
 export default function Dashboard() {
     return (
-        <AuthenticatedLayout
-            // header={
-            //     <h2 className="text-xl font-semibold leading-tight text-gray-800">
-            //         ダッシュボード
-            //     </h2>
-            // }
-        >
+        <AuthenticatedLayout>
             <Head title="Dashboard" />
 
             <div className="py-12">

--- a/src/resources/js/store/checklistSlice.js
+++ b/src/resources/js/store/checklistSlice.js
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
+
 export const fetchCheckLists = createAsyncThunk(
   'checkLists/fetchCheckLists',
   async (workflowId) => {
@@ -18,6 +19,9 @@ export const addCheckList = createAsyncThunk(
   }
 );
 
+export const selectCheckListsByFlowNumber = (flowNumber) => (state) => {
+  return state.checklists ? state.checklists.filter(checklist => checklist.flownumber_for_checklist === flowNumber) : [];
+};
 
 const checkListSlice = createSlice({
   name: 'checkLists',

--- a/src/resources/js/store/checklistSlice.js
+++ b/src/resources/js/store/checklistSlice.js
@@ -2,38 +2,45 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
 export const fetchCheckLists = createAsyncThunk(
-    'checklists/fetchCheckLists',
-    async (workflowId) => {
-        const response = await axios.get(`/api/workflows/${workflowId}/checklists`);
-        return response.data;
-    }
+  'checkLists/fetchCheckLists',
+  async (workflowId) => {
+      const response = await axios.get(`/api/workflows/${workflowId}/checklists`);
+      return response.data; // APIからのレスポンスをそのまま返す
+      console.log(response.data); // ここでデータ構造を確認
+  }
 );
 
 export const addCheckList = createAsyncThunk(
-    'checklists/addCheckList',
-    async ({ workflowId, checklist }) => {
-        const response = await axios.post(`/api/workflows/${workflowId}/checklists`, checklist);
-        return response.data;
-    }
+  'checklists/addCheckList',
+  async ({ workflowId, checklist }) => {
+      const response = await axios.post(`/api/workflows/${workflowId}/checklists`, checklist);
+      return response.data;
+  }
 );
 
-const checklistSlice = createSlice({
-    name: 'checklists',
-    initialState: {
-        checkLists: [],
-        status: 'idle',
-        error: null,
-    },
-    reducers: {},
-    extraReducers: (builder) => {
-        builder
-            .addCase(fetchCheckLists.fulfilled, (state, action) => {
-                state.checkLists = action.payload;
-            })
-            .addCase(addCheckList.fulfilled, (state, action) => {
-                state.checkLists.push(action.payload);
-            });
-    },
+
+const checkListSlice = createSlice({
+  name: 'checkLists',
+  initialState: {},
+  reducers: {},
+  extraReducers: (builder) => {
+      builder
+          .addCase(fetchCheckLists.fulfilled, (state, action) => {
+              const newCheckLists = action.payload.reduce((acc, checklist) => {
+                  const flowNumber = checklist.flownumber_for_checklist;
+                  if (!acc[flowNumber]) {
+                      acc[flowNumber] = [];
+                  }
+                  acc[flowNumber].push(checklist);
+                  return acc;
+              }, {});
+              console.log(JSON.stringify(newCheckLists, null, 2));
+              return { ...state, ...newCheckLists }; // ステートを更新
+          });
+  },
 });
 
-export default checklistSlice.reducer;
+// セレクタを追加（必要に応じて）
+export const selectCheckListsByColumn = (state) => state.checkLists;
+
+export default checkListSlice.reducer;

--- a/src/resources/js/store/checklistSlice.js
+++ b/src/resources/js/store/checklistSlice.js
@@ -1,0 +1,39 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const fetchCheckLists = createAsyncThunk(
+    'checklists/fetchCheckLists',
+    async (workflowId) => {
+        const response = await axios.get(`/api/workflows/${workflowId}/checklists`);
+        return response.data;
+    }
+);
+
+export const addCheckList = createAsyncThunk(
+    'checklists/addCheckList',
+    async ({ workflowId, checklist }) => {
+        const response = await axios.post(`/api/workflows/${workflowId}/checklists`, checklist);
+        return response.data;
+    }
+);
+
+const checklistSlice = createSlice({
+    name: 'checklists',
+    initialState: {
+        checkLists: [],
+        status: 'idle',
+        error: null,
+    },
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchCheckLists.fulfilled, (state, action) => {
+                state.checkLists = action.payload;
+            })
+            .addCase(addCheckList.fulfilled, (state, action) => {
+                state.checkLists.push(action.payload);
+            });
+    },
+});
+
+export default checklistSlice.reducer;

--- a/src/resources/js/store/store.js
+++ b/src/resources/js/store/store.js
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import memberReducer from './memberSlice';
 import flowstepsReducer from './flowstepsSlice';
+import checklistsReducer from './checklistSlice';
 import memberReducerForGuest from './memberSliceForGuest';
 
 
@@ -8,6 +9,7 @@ const store = configureStore({
     reducer: {
         members: memberReducer,
         flowsteps: flowstepsReducer,
+        checklists: checklistsReducer,
         membersForGuest: memberReducerForGuest
     },
 });

--- a/src/resources/js/store/store.js
+++ b/src/resources/js/store/store.js
@@ -9,7 +9,7 @@ const store = configureStore({
     reducer: {
         members: memberReducer,
         flowsteps: flowstepsReducer,
-        checklists: checklistsReducer,
+        checkLists: checklistsReducer,
         membersForGuest: memberReducerForGuest
     },
 });

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -56,3 +56,12 @@ Route::get('/api/workflows', [WorkFlowController::class, 'index'])->name('workfl
 Route::post('/api/workflows', [WorkFlowController::class, 'store'])->name('workflow.create');
 
 
+use App\Http\Controllers\ChecklistController;
+Route::get('/api/workflows/{workflowId}/checklists', [ChecklistController::class, 'index']);
+Route::post('/api/workflows/{workflowId}/checklists', [ChecklistController::class, 'store']);
+Route::delete('/api/checklists/{id}', [ChecklistController::class, 'destroy']);
+
+use App\Http\Controllers\CheckitemController;
+Route::get('/api/workflows/{workflowId}/checklists/{checklistId}/checkitems', [CheckitemController::class, 'index']);
+Route::post('/api/workflows/{workflowId}/checklists/{checklistId}/checkitems', [CheckitemController::class, 'store']);
+Route::delete('/api/checkitems/{id}', [CheckitemController::class, 'destroy']);


### PR DESCRIPTION
## GitHub Issue Ticket
- close #105 

## やった事
`このプルリクエストにて何をしたのか？`
チェック項目をLaravelのデータベースに追加できるように実装
 - Laravel
   - データベースの変更
     - checklist テーブル
     - checkitemテーブル(現状使っていない)
     - checklist_chekuitemテーブルの追加(現状使っていない)
 - React
   - checklist追加のRedux Sliceを追加  

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
各ステップ間で次のステップに進む際のチェック事項を作成できることにより
Documentコンポーネントに記載する機能の充実化が図れる。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
