### PR TITLE
Feature 2024.10.28.06.37 ダッシュボードに自分の作成したworkflowを表示する機能を実装する #107

### DIFF
--- a/src/app/Http/Controllers/WorkflowController.php
+++ b/src/app/Http/Controllers/WorkflowController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Workflow;
+use Inertia\Inertia;
 use Illuminate\Http\Request;
 
 class WorkflowController extends Controller
@@ -37,6 +38,14 @@ class WorkflowController extends Controller
         'name' => $workflow->name,
         'message' => 'Workflow created successfully.',
     ]);
+  }
+
+  public function show($id)
+  {
+      $workflow = Workflow::findOrFail($id);
+      return Inertia::render('WorkflowDetailPage', [
+          'workflow' => $workflow
+      ]);
   }
       
 }

--- a/src/resources/css/WorkflowDetailPage.css
+++ b/src/resources/css/WorkflowDetailPage.css
@@ -1,0 +1,3 @@
+.MatrixView-on-WorkflowDetailPage {
+  display: flex;
+}

--- a/src/resources/js/Pages/Dashboard.jsx
+++ b/src/resources/js/Pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
+import { Link, usePage } from '@inertiajs/react';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 
@@ -32,6 +33,9 @@ export default function Dashboard() {
                                 <div key={workflow.id} className="bg-white shadow-md rounded-lg p-4 hover:shadow-lg transition-shadow duration-300">
                                     <h3 className="font-semibold text-lg">{workflow.name}</h3>
                                     {/* <p className="text-gray-500">詳細情報がここに入ります</p> */}
+                                    <Link href={route('workflows.show', workflow.id)} className="mt-2 text-blue-500 hover:underline">
+                                         詳細を見る
+                                    </Link>
                                     {/* <button className="mt-2 text-blue-500 hover:underline">
                                         詳細を見る
                                     </button> */}

--- a/src/resources/js/Pages/Dashboard.jsx
+++ b/src/resources/js/Pages/Dashboard.jsx
@@ -1,7 +1,24 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 
 export default function Dashboard() {
+    const [workflows, setWorkflows] = useState([]);
+
+    useEffect(() => {
+        const fetchWorkflows = async () => {
+            try {
+                const response = await axios.get('/api/workflows');
+                setWorkflows(response.data);
+            } catch (error) {
+                console.error("Error fetching workflows:", error);
+            }
+        };
+
+        fetchWorkflows();
+    }, []);
+
     return (
         <AuthenticatedLayout>
             <Head title="Dashboard" />
@@ -9,8 +26,17 @@ export default function Dashboard() {
             <div className="py-12">
                 <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            ログインしました
+                        <div className="p-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            <h2 className="text-lg font-semibold mb-4">あなたが作成したワークフロー</h2>
+                            {workflows.map(workflow => (
+                                <div key={workflow.id} className="bg-white shadow-md rounded-lg p-4 hover:shadow-lg transition-shadow duration-300">
+                                    <h3 className="font-semibold text-lg">{workflow.name}</h3>
+                                    {/* <p className="text-gray-500">詳細情報がここに入ります</p> */}
+                                    {/* <button className="mt-2 text-blue-500 hover:underline">
+                                        詳細を見る
+                                    </button> */}
+                                </div>
+                            ))}
                         </div>
                     </div>
                 </div>

--- a/src/resources/js/Pages/WorkflowDetailPage.jsx
+++ b/src/resources/js/Pages/WorkflowDetailPage.jsx
@@ -1,0 +1,30 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+import MatrixView from '@/Components/MatrixView'; // MatrixView コンポーネントをインポート
+import '../../css/WorkflowDetailPage.css'
+
+export default function WorkflowDetailPage({ workflow }) {
+    return (
+        <AuthenticatedLayout>
+            <Head title={workflow.name} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6">
+                            <h2 className="text-2xl font-bold">{workflow.name}</h2>
+                            <p className="mt-4"></p>
+                            <ul className="list-disc list-inside mt-2">
+                              <li>作成日: {new Date(workflow.created_at).toLocaleString()}</li>
+                              <li>更新日: {new Date(workflow.updated_at).toLocaleString()}</li>
+                            </ul>
+                            <div class="MatrixView-on-WorkflowDetailPage">
+                              <MatrixView workflowId={workflow.id} />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -52,8 +52,9 @@ Route::get('/new-matrixflow', [MatrixFlowController::class, 'renderNewMatrixFlow
 Route::get('/create-matrixflow-for-guest', [MatrixFlowController::class, 'renderCreateMatrixFlowPageforGuest'])->name('guest.matrixflow.create');
 
 use App\Http\Controllers\WorkflowController;
-Route::get('/api/workflows', [WorkFlowController::class, 'index'])->name('workflow.index');
-Route::post('/api/workflows', [WorkFlowController::class, 'store'])->name('workflow.create');
+Route::get('/api/workflows', [WorkflowController::class, 'index'])->name('workflow.index');
+Route::post('/api/workflows', [WorkflowController::class, 'store'])->name('workflow.create');
+Route::get('/api/workflows/{id}', [WorkflowController::class, 'show'])->name('workflows.show');
 
 
 use App\Http\Controllers\ChecklistController;


### PR DESCRIPTION
## GitHub Issue Ticket
- close #107 

## やった事
`このプルリクエストにて何をしたのか？`
 - ダッシュボード画面で自分の作成したワークフロー一覧を閲覧することができるように実装
 - ダッシュボードのワークフロー一覧から詳細画面への導線を実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
ダッシュボードへアクセスした時の表示要素の充実化

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
