### PR TITLE
Feature_2024.10.31.03.52_コンポーネントの修正( Document / checklistの内容をDocument…

### DIFF
--- a/src/resources/css/Document.css
+++ b/src/resources/css/Document.css
@@ -2,27 +2,26 @@
 }
 
 .document-container h2 {
-  font-size: 21px; /* 見出しのフォントサイズ */
+  font-size: 18px; /* 見出しのフォントサイズ */
   color: #333; /* 見出しの色 */
-  margin-bottom: 20px; /* 見出し下の余白 */
+  margin-bottom: 10px;
   text-align: left; /* 左揃え */
 }
 
 .chapter {
-  margin-bottom: 30px; /* 各章の下余白 */
+  margin-bottom: 10px;
 }
 
 .chapter h3 {
-  font-size: 24px; /* 章の見出しのフォントサイズ */
+  font-size: 16px; /* 章の見出しのフォントサイズ */
   color: #555; /* 章見出しの色 */
-  margin-bottom: 10px; /* 章見出しの下余白 */
 }
 
 .chapter p {
-  font-size: 18px; /* 段落のフォントサイズ */
-  color: #666; /* 段落の色 */
+  font-size: 16px; /* 段落のフォントサイズ */
+  color: black; /* 段落の色 */
   margin: 5px 0; /* 段落の上下余白 */
-  padding-left: 20px; /* 左側のインデント */
+  padding-left: 10px; /* 左側のインデント */
   /* または */
   /* text-indent: 20px; インデントを段落の最初の行にのみ適用する場合 */
 }
@@ -30,4 +29,58 @@
 .chapter p span {
   font-weight: bold; /* 太字 */
   color: #2c3e50; /* 強調色 */
+}
+
+.checklist-title {
+  padding-left: 15px; /* 左側のインデント */
+  font-size: 16px; /* 段落のフォントサイズ */
+  
+}
+
+.checklist-container-on-document {
+  padding-left: 30px; /* 左側のインデント */ 
+}
+
+.checklist-on-document {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.checklist-container-card {
+  background-color: whitesmoke; /* カードの背景色 */
+  border-radius: 8px;        /* 角の丸み */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* カードの影 */
+  padding: 8px;             /* カードの内側の余白 */
+  margin-left: 25px;       /* カード間の余白 */
+  margin-top: 16px;       /* カード間の余白 */
+  margin-bottom: 16px;       /* カード間の余白 */
+}
+
+.checklist-card {
+  background-color: white; /* カードの背景色 */
+  border-radius: 8px;        /* 角の丸み */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* カードの影 */
+  padding: 16px;           /* カードの内側の余白 */
+  margin-left: 35px;       /* カード間の余白 */
+  margin-bottom: 16px;       /* カード間の余白 */
+}
+
+.checklist-title {
+  font-size: 16px;
+  margin-bottom: 8px;
+  margin-left: 15px;
+}
+
+.checklist-container {
+  list-style: none;
+  padding: 0;
+}
+
+.icon-on-checklist-card {
+  margin-right: 10px;
+}
+
+.non-flowstep-message-on-document {
+  margin-left: 35px;
+  color: darkgray;
 }

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -1,20 +1,23 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchFlowsteps } from '../store/flowstepsSlice'; 
+import { fetchFlowsteps } from '../store/flowstepsSlice';
+import { fetchCheckLists } from '../store/checklistSlice';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
 import '../../css/Document.css';
 
-const Document = () => {
+const Document = ({ workflowId }) => {
   const dispatch = useDispatch();
 
-  // Get flowsteps from Redux store
+  // Redux ストアから flowsteps と checklists を取得
   const flowsteps = useSelector((state) => state.flowsteps);
+  const checklists = useSelector((state) => state.checkLists);
 
   useEffect(() => {
-    // Fetch flowsteps on component mount
-    dispatch(fetchFlowsteps());
-  }, [dispatch]);
+    dispatch(fetchFlowsteps(workflowId));
+    dispatch(fetchCheckLists(workflowId));
+  }, [dispatch, workflowId]);
 
-  // flowstepsが配列であることを確認
   if (!Array.isArray(flowsteps)) {
     return <div>Error: flowsteps is not an array.</div>;
   }
@@ -25,17 +28,37 @@ const Document = () => {
       {flowsteps.length === 0 ? (
         <p>フローステップはまだありません。</p>
       ) : (
-        flowsteps.map((flowstep, index) => (
-          <div key={flowstep.id} className="chapter">
-            <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
-            <p>
-              {flowstep.members && flowstep.members.length > 0
-                ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
-                : 'Unknown Member が行うタスク:'}
-              {flowstep.content}
-            </p>
-          </div>
-        ))
+        flowsteps.map((flowstep, index) => {
+          // 各フローステップに対応するチェックリストを取得
+          const flowstepChecklists = checklists[flowstep.flow_number] || [];
+          console.log("flowstepChecklists:", flowstepChecklists);
+
+          return (
+            <div key={flowstep.id} className="chapter">
+              <h2 className="chapter">{index + 1}: {flowstep.name}</h2>
+              <p>
+                {flowstep.members && flowstep.members.length > 0
+                  ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
+                  : 'Unknown Member が行うタスク:'}
+                {flowstep.content}
+              </p>
+
+              {/* チェック項目を表示 */}
+              <div className="checklist-container-card">
+                <div className="checklist-title">チェック項目</div>
+                {flowstepChecklists.length > 0 ? (
+                  <ul className="checklist-container">
+                    {flowstepChecklists.map((checklist) => (
+                      <li key={checklist.id} className="checklist-card"><FontAwesomeIcon icon={faClipboardCheck} className="icon-on-checklist-card" />{checklist.name}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="non-flowstep-message-on-document">チェック項目はありません。</div>
+                )}
+              </div>
+            </div>
+          );
+        })
       )}
     </div>
   );

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -60,7 +60,9 @@ const CreateMatrixFlowPage = (props) => {
             <FlashMessage message={flashMessage} />
             <div className="content-container">
                 <div className="sidebar">
-                    <Document />
+                    <Document 
+                        workflowId={workflowId}
+                    />
                 </div>
                 <div className="main-content">
                     <MatrixView


### PR DESCRIPTION
…コンポーネント上に表示する  )

## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
Documentコンポーネント上にChecklistの内容を表示するように実装

下記定数を定義して flow_number の表示箇所に、チェックリストを表示
``` javascript
// 各フローステップに対応するチェックリストを取得
const flowstepChecklists = checklists[flowstep.flow_number] || [];
``` 

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Documentコンポーネント上にChecklistの内容を表示するようにし、Documentコンポーネントの内容を拡充

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
