### PR TITLE
Feature 2024.11.10.04.43 モーダルの開閉のredux化・flowstep更新用モーダルの実装

### DIFF
--- a/src/app/Http/Controllers/FlowstepController.php
+++ b/src/app/Http/Controllers/FlowstepController.php
@@ -74,7 +74,7 @@ class FlowstepController extends Controller
         return response()->json(['message' => 'Flow step deleted successfully'], 200);
     }
 
-    public function update(Request $request, $id)
+    public function updateName(Request $request, $id)
     {
         // Validate the request
         $request->validate([

--- a/src/app/Http/Controllers/FlowstepController.php
+++ b/src/app/Http/Controllers/FlowstepController.php
@@ -74,6 +74,23 @@ class FlowstepController extends Controller
         return response()->json(['message' => 'Flow step deleted successfully'], 200);
     }
 
+    public function update(Request $request, $id)
+    {
+        // Validate the request
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'flow_number' => 'required|integer'
+        ]);
+
+        // Find the FlowStep and update it
+        $flowStep = FlowStep::findOrFail($id);
+        $flowStep->name = $request->input('name');
+        $flowStep->flow_number = $request->input('flow_number');
+        $flowStep->save();
+
+        return response()->json($flowStep, 200); // Return updated flow step
+    }
+
     public function updateName(Request $request, $id)
     {
         // Validate the request

--- a/src/resources/css/Document.css
+++ b/src/resources/css/Document.css
@@ -87,7 +87,7 @@
   font-size: 16px;
   margin-bottom: 8px;
   margin-left: 15px;
-  padding-right: 100px;
+  max-width: 200px;
 }
 
 .checklist-container {

--- a/src/resources/css/Flowstep.css
+++ b/src/resources/css/Flowstep.css
@@ -15,9 +15,18 @@
   background-color: #e0f7fa; /* Slightly darker blue on hover */
 }
 
-.flow-step-name {
+.flowstep-name {
   color: #333; /* Darker text color */
   font-size: 1.2em; /* Larger font size */
   text-align: center; /* Center the text */
   margin: 0; /* Remove default margin */
+  margin-left: 5px;
+}
+
+.flowstep-name-container {
+  display: flex;
+}
+
+.flowstep-name-edit-button {
+  margin-left: 5px;
 }

--- a/src/resources/css/Flowstep.css
+++ b/src/resources/css/Flowstep.css
@@ -27,6 +27,15 @@
   display: flex;
 }
 
+.button-container-for-flowstep {
+  display: flex;
+  justify-content: center;
+}
+
 .flowstep-name-edit-button {
   margin-left: 5px;
+}
+
+.faPencil-button-for-flowstep {
+  margin-right: 10px;
 }

--- a/src/resources/js/Components/CheckListModal.jsx
+++ b/src/resources/js/Components/CheckListModal.jsx
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import '../../css/CheckListModal.css';
+import { closeCheckListModal } from '../store/modalSlice';
 
-const CheckListModal = ({ isOpen, onClose, children }) => {
-    if (!isOpen) return null; // モーダルが開いていない場合は何も表示しない
+const CheckListModal = ({ children }) => {
+    const dispatch = useDispatch();
+    const isCheckListModalOpen = useSelector(state => state.modal.isCheckListModalOpen);
+
+    // モーダルが開いていない場合は何も表示しない
+    if (!isCheckListModalOpen) return null;
+
+    // モーダルを閉じる
+    const handleCloseChecklistModal = () => {
+        dispatch(closeCheckListModal());
+    };
 
     return (
-        <div className="modal-overlay" onClick={onClose}>
+        <div className="modal-overlay" onClick={handleCloseChecklistModal}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-                <button className="modal-close" onClick={onClose}>×</button>
+                <button className="modal-close" onClick={handleCloseChecklistModal}>×</button>
                 {children}
             </div>
         </div>

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -3,6 +3,8 @@ import { useDrag } from 'react-dnd';
 import '../../css/Flowstep.css';
 import { useDispatch } from 'react-redux';
 import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepAsync } from '../store/flowstepsSlice'; // Import the async actions
+import { openUpdateFlowstepModal } from '../store/modalSlice';
+import { setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit, faSave, faCancel, faPencil } from '@fortawesome/free-solid-svg-icons';
 
@@ -48,6 +50,13 @@ const FlowStep = ({ flowstep, workflowId }) => {
         dispatch(fetchFlowsteps(workflowId));
     };
 
+    const handleOpenUpdateFlowstepModal = (member, stepNumber) => {
+        dispatch(setSelectedMember(member));
+        dispatch(setSelectedStepNumber(stepNumber));
+        dispatch(openUpdateFlowstepModal(member, stepNumber));
+    };
+
+
     return (
         <div 
             ref={drag} 
@@ -78,7 +87,7 @@ const FlowStep = ({ flowstep, workflowId }) => {
                         )}
                     </div>
                     <div className="button-container-for-flowstep">
-                        <div className="faPencil-button-for-flowstep">
+                        <div onClick={handleOpenUpdateFlowstepModal} className="faPencil-button-for-flowstep">
                             <FontAwesomeIcon icon={faPencil} />
                         </div>
                         <div onClick={handleDelete} className="delete-button" disabled={isDeleting}>

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDrag } from 'react-dnd';
 import '../../css/Flowstep.css';
 import { useDispatch } from 'react-redux';
-import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepAsync } from '../store/flowstepsSlice'; // Import the async actions
+import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepName } from '../store/flowstepsSlice'; // Import the async actions
 import { openUpdateFlowstepModal } from '../store/modalSlice';
 import { setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -45,7 +45,7 @@ const FlowStep = ({ flowstep, workflowId }) => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        await dispatch(updateFlowstepAsync({ id: flowstep.id, updatedFlowstep: { name: newName } }));
+        await dispatch(updateFlowstepName({ id: flowstep.id, updatedFlowstep: { name: newName } }));
         setIsEditing(false); // Close the form after submitting
         dispatch(fetchFlowsteps(workflowId));
     };

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -4,11 +4,11 @@ import '../../css/Flowstep.css';
 import { useDispatch } from 'react-redux';
 import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepName } from '../store/flowstepsSlice'; // Import the async actions
 import { openUpdateFlowstepModal } from '../store/modalSlice';
-import { setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
+import { setSelectedFlowstep, setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit, faSave, faCancel, faPencil } from '@fortawesome/free-solid-svg-icons';
 
-const FlowStep = ({ flowstep, workflowId }) => {
+const FlowStep = ({ flowstep, flowNumber, workflowId }) => {
     if (!flowstep) {
         return <div>フローステップのデータがありません</div>;
     }
@@ -53,6 +53,7 @@ const FlowStep = ({ flowstep, workflowId }) => {
     const handleOpenUpdateFlowstepModal = (member, stepNumber) => {
         dispatch(setSelectedMember(member));
         dispatch(setSelectedStepNumber(stepNumber));
+        dispatch(setSelectedFlowstep(flowstep));
         dispatch(openUpdateFlowstepModal(member, stepNumber));
     };
 

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import { useDrag } from 'react-dnd';
 import '../../css/Flowstep.css';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepName } from '../store/flowstepsSlice'; // Import the async actions
 import { openUpdateFlowstepModal } from '../store/modalSlice';
 import { setSelectedFlowstep, setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit, faSave, faCancel, faPencil } from '@fortawesome/free-solid-svg-icons';
 
-const FlowStep = ({ flowstep, flowNumber, workflowId }) => {
+const FlowStep = ({ member, flowstep, flowNumber, workflowId }) => {
     if (!flowstep) {
         return <div>フローステップのデータがありません</div>;
     }
@@ -26,6 +26,18 @@ const FlowStep = ({ flowstep, flowNumber, workflowId }) => {
     const [newName, setNewName] = useState(flowstep.name); // Initial value from flowstep.name
     const [isHovered, setIsHovered] = useState(false); // Hover state
     const dispatch = useDispatch();
+
+    // Reduxから選択されたメンバーとフローステップの状態を取得
+    const selectedMember = useSelector((state) => state.selected.selectedMember);
+    const selectedStepNumber = useSelector((state) => state.selected.selectedStepNumber);
+    const selectedFlowstep = useSelector((state) => state.selected.selectedFlowstep);
+
+    // デバッグ用ログ
+    console.log('selectedMember on Flowstep.jsx:', selectedMember);
+    console.log('selectedFlowstep on Flowstep.jsx:', selectedFlowstep);
+    console.log('selectedStepNumber on Flowstep.jsx:', selectedStepNumber);
+    
+    
 
     const handleDelete = async () => {
         setIsDeleting(true); // Set deleting state
@@ -50,11 +62,11 @@ const FlowStep = ({ flowstep, flowNumber, workflowId }) => {
         dispatch(fetchFlowsteps(workflowId));
     };
 
-    const handleOpenUpdateFlowstepModal = (member, stepNumber) => {
-        dispatch(setSelectedMember(member));
+    const handleOpenUpdateFlowstepModal = (member, flowstep, stepNumber) => {
+        dispatch(setSelectedMember(selectedMember));
         dispatch(setSelectedStepNumber(stepNumber));
         dispatch(setSelectedFlowstep(flowstep));
-        dispatch(openUpdateFlowstepModal(member, stepNumber));
+        dispatch(openUpdateFlowstepModal());
     };
 
 

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -4,7 +4,7 @@ import '../../css/Flowstep.css';
 import { useDispatch } from 'react-redux';
 import { fetchFlowsteps, deleteFlowstepAsync, updateFlowstepAsync } from '../store/flowstepsSlice'; // Import the async actions
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash, faEdit, faSave, faCancel } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faEdit, faSave, faCancel, faPencil } from '@fortawesome/free-solid-svg-icons';
 
 const FlowStep = ({ flowstep, workflowId }) => {
     if (!flowstep) {
@@ -77,9 +77,14 @@ const FlowStep = ({ flowstep, workflowId }) => {
                             </button>
                         )}
                     </div>
-                    <button onClick={handleDelete} className="delete-button" disabled={isDeleting}>
-                        <FontAwesomeIcon icon={faTrash} />
-                    </button>
+                    <div className="button-container-for-flowstep">
+                        <div className="faPencil-button-for-flowstep">
+                            <FontAwesomeIcon icon={faPencil} />
+                        </div>
+                        <div onClick={handleDelete} className="delete-button" disabled={isDeleting}>
+                            <FontAwesomeIcon icon={faTrash} />
+                        </div>
+                    </div>
                 </>
             )}
         </div>

--- a/src/resources/js/Components/Flowstep.jsx
+++ b/src/resources/js/Components/Flowstep.jsx
@@ -22,6 +22,7 @@ const FlowStep = ({ flowstep, workflowId }) => {
     const [isDeleting, setIsDeleting] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [newName, setNewName] = useState(flowstep.name); // Initial value from flowstep.name
+    const [isHovered, setIsHovered] = useState(false); // Hover state
     const dispatch = useDispatch();
 
     const handleDelete = async () => {
@@ -48,7 +49,13 @@ const FlowStep = ({ flowstep, workflowId }) => {
     };
 
     return (
-        <div ref={drag} className="flow-step" style={{ opacity: isDragging ? 0.5 : 1 }}>
+        <div 
+            ref={drag} 
+            className="flow-step" 
+            style={{ opacity: isDragging ? 0.5 : 1 }} 
+            onMouseEnter={() => setIsHovered(true)} // Set hover state
+            onMouseLeave={() => setIsHovered(false)} // Reset hover state
+        >
             {isEditing ? (
                 <form onSubmit={handleSubmit} className="edit-flowstep-form">
                     <input 
@@ -62,10 +69,14 @@ const FlowStep = ({ flowstep, workflowId }) => {
                 </form>
             ) : (
                 <>
-                    <h4 className="flow-step-name">{flowstep.name}</h4>
-                    <button onClick={handleEditClick} className="edit-button">
-                        <FontAwesomeIcon icon={faEdit} />
-                    </button>
+                    <div className="flowstep-name-container">
+                        <div className="flowstep-name">{flowstep.name}</div>
+                        {isHovered && ( // Show edit button only on hover
+                            <button onClick={handleEditClick} className="flowstep-name-edit-button">
+                                <FontAwesomeIcon icon={faEdit} />
+                            </button>
+                        )}
+                    </div>
                     <button onClick={handleDelete} className="delete-button" disabled={isDeleting}>
                         <FontAwesomeIcon icon={faTrash} />
                     </button>

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -17,8 +17,10 @@ import { faUser, faSquarePlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBa
 import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import AddFlowStepForm from '../Components/AddFlowStepForm';
+import UpdateFlowStepForm from '../Components/UpdateFlowStepForm';
 import AddCheckListForm from '../Components/AddCheckListForm';
 import ModalforAddFlowStepForm from '../Components/ModalforAddFlowStepForm';
+import ModalforUpdateFlowStepForm from '../Components/ModalforUpdateFlowStepForm';
 import ModalforAddCheckListForm from '../Components/ModalforAddCheckListForm';
 import CheckListModal from '../Components/CheckListModal';
 import CheckListModalContent from '../Components/CheckListModalContent';
@@ -336,6 +338,7 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
     const members = useSelector((state) => state.members);
     const flowsteps = useSelector((state) => state.flowsteps);
     const isAddFlowstepModalOpen = useSelector((state) => state.modal.isAddFlowstepModalOpen);
+    const isUpdateFlowstepModalOpen = useSelector((state) => state.modal.isUpdateFlowstepModalOpen);
     
     useEffect(() => {
         dispatch(fetchMembers(workflowId));
@@ -544,6 +547,21 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                         workflowId={workflowId}
                     />
                 </ModalforAddFlowStepForm>
+            )}
+
+            {/* モーダルの表示 */}
+            {isUpdateFlowstepModalOpen && (
+                <ModalforUpdateFlowStepForm>
+                    <UpdateFlowStepForm
+                        members={orderedMembers}
+                        member={selectedMember}
+                        stepNumber={selectedStepNumber}
+                        nextStepNumber={maxFlowNumber + 1}
+                        onClose={closeAddFlowStepModal}
+                        onFlowStepAdded={onFlowStepAdded}
+                        workflowId={workflowId}
+                    />
+                </ModalforUpdateFlowStepForm>
             )}
 
 

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -103,6 +103,14 @@ const MatrixCol = ({ openAddFlowStepModal, openAddCheckListModal, flowNumber, on
     // Ensure flowsteps is an array
     const validFlowsteps = Array.isArray(flowsteps) ? flowsteps : [];
 
+    const isAddFlowstepModalOpen = useSelector(state => state.modal.isAddFlowstepModalOpen);
+    const handleOpenAddFlowstepModal = (member, stepNumber) => {
+        dispatch(setSelectedMember(member));
+        dispatch(setSelectedStepNumber(stepNumber));
+        dispatch(openAddFlowstepModal(member, stepNumber));
+    };
+
+
     return (
         <td className="matrix-cell" ref={drop} style={{ backgroundColor: isOver ? 'lightblue' : 'white' }}>
             {/* flowstepsをループして、flow_numberとメンバーに基づいて表示 */}
@@ -130,7 +138,7 @@ const MatrixCol = ({ openAddFlowStepModal, openAddCheckListModal, flowNumber, on
                 <div className="member-cell">
                     <button 
                         className="add-step-button" 
-                        onClick={() => openModal(member, flowNumber)}
+                        onClick={() => handleOpenAddFlowstepModal(member, flowNumber)}
                     >
                         <FontAwesomeIcon icon={faSquarePlus} />
                     </button>

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -35,24 +35,20 @@ const CheckItemColumn = ({ member, flowNumber, openAddCheckListModal, workflowId
     const checkListsForFlowNumber = checkListsFromStore[flowNumber] || [];
     
     const [selectedCheckList, setSelectedCheckList] = useState(null); // 選択されたチェックリストを保持する状態
-    const [isModalOpen, setIsModalOpen] = useState(false); // モーダルのオープン状態を管理
-
+    
     const hasCheckList = checkListsForFlowNumber.some(checklist => checklist.workflow_id === workflowId);
     console.log("hasCheckList:", hasCheckList);
 
-    const handleCheckListClick = (checklist) => {
+    // モーダルを開く
+    const isCheckListModalOpen = useSelector(state => state.modal.isCheckListModalOpen);
+    const handleOpenChecklistModal = (checklist) => {
         dispatch(openCheckListModal({ checkList: checklist }));
-    };
-
-    const closeModal = () => {
-        setIsModalOpen(false); // モーダルを閉じる
-        setSelectedCheckList(null); // 選択をリセット
     };
 
     return (
         <td className="matrix-check-item-column">
             {hasCheckList ? (
-                <div className="check-item" onClick={() => handleCheckListClick(checkListsForFlowNumber[0])}>
+                <div className="check-item" onClick={() => handleOpenChecklistModal(checkListsForFlowNumber[0])}>
                     <FontAwesomeIcon icon={faClipboardCheck} /> {/* 1つだけ表示 */}
                 </div>
             ) : (
@@ -62,10 +58,8 @@ const CheckItemColumn = ({ member, flowNumber, openAddCheckListModal, workflowId
             )}
 
             {/* モーダルの表示 */}
-            {isModalOpen && (
+            {isCheckListModalOpen && (
                 <CheckListModal 
-                    isOpen={isModalOpen} 
-                    onClose={closeModal} 
                     checkList={selectedCheckList} // 選択されたチェックリストをモーダルに渡す
                 >
                     <CheckListModalContent

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { fetchCheckLists, selectCheckListsByColumn } from '../store/checklistSlice';
-import { openCheckListModal } from '../store/modalSlice';
+import { openCheckListModal, openAddFlowstepModal } from '../store/modalSlice';
 
 // FontAwesomeのアイコンのインポート
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -149,7 +149,7 @@ const MatrixRow = ({
     updateFlowStepNumber,
     onMemberDelete,
     workflowId,
-}) => {
+    }) => {
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [newName, setNewName] = useState(member.name);
@@ -172,6 +172,12 @@ const MatrixRow = ({
             console.log("checkListsFromStore by useEffect on MatrixRow" ,JSON.stringify(checkListsFromStore, null, 2));
         }
     }, [checkListsFromStore]);
+
+    const isAddFlowstepModalOpen = useSelector(state => state.modal.isAddFlowstepModalOpen);
+    const handleOpenAddFlowstepModal = (member, selectedStepNumber) => {
+        dispatch(openAddFlowstepModal(member, selectedStepNumber));
+    };
+
 
     const handleAddCheckItem = (flowNumber) => {
         const newCheckItemId = Date.now(); // 一意のIDを生成
@@ -287,7 +293,7 @@ const MatrixRow = ({
                 );
             })}
             <td className="matrix-cell next-step-column">
-                <button onClick={() => openAddFlowStepModal(member, maxFlowNumber + 1)} className="add-step-button">
+                <button onClick={() => handleOpenAddFlowstepModal(member, maxFlowNumber + 1)} className="add-step-button">
                     <FontAwesomeIcon icon={faSquarePlus} />
                 </button>
             </td>
@@ -298,18 +304,18 @@ const MatrixRow = ({
 
 const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflowId }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const { isAddFlowStepModalOpen } = useSelector((state) => state.modal);
     const [isModalforAddCheckListFormOpen, setIsModalforAddCheckListFormOpen] = useState(false);
     const [selectedMember, setSelectedMember] = useState(null);
     const [selectedStepNumber, setSelectedStepNumber] = useState(null);
     const [maxFlowNumber, setMaxFlowNumber] = useState(0);
     const [orderedMembers, setOrderedMembers] = useState([]);
-
+    
     const dispatch = useDispatch();
-
+    
     // Reduxストアから指定のworkflowIdに関連するメンバーとフローステップを取得
     const members = useSelector((state) => state.members);
     const flowsteps = useSelector((state) => state.flowsteps);
+    const isAddFlowstepModalOpen = useSelector((state) => state.modal.isAddFlowstepModalOpen);
     
     useEffect(() => {
         dispatch(fetchMembers(workflowId));
@@ -339,6 +345,12 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
         setSelectedMember(member);
         setSelectedStepNumber(stepNumber);
         setIsModalOpen(true);
+    };
+
+    const handleOpenAddFlowstepModalonMatrixView = (member, stepNumber) => {
+        setSelectedMember(member);
+        setSelectedStepNumber(stepNumber);
+        dispatch(openAddFlowStepModal());
     };
 
     const closeAddFlowStepModal = () => {
@@ -435,7 +447,7 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                                     </div>
                                 </td>
                                 <td className="matrix-cell next-step-column">
-                                    <button onClick={() => openAddFlowStepModal(null, 2)} className="add-step-button">
+                                    <button onClick={() => handleOpenAddFlowstepModalonMatrixView(null, 2)} className="add-step-button">
                                         <FontAwesomeIcon icon={faSquarePlus} />
                                     </button>
                                 </td>
@@ -499,7 +511,9 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                     </table>
                 )}
 
-                <ModalforAddFlowStepForm isOpen={isModalOpen} onClose={closeAddFlowStepModal}>
+            {/* モーダルの表示 */}
+            {isAddFlowstepModalOpen && (
+                <ModalforAddFlowStepForm isOpen={isAddFlowstepModalOpen} onClose={closeAddFlowStepModal}>
                     <AddFlowStepForm
                         members={orderedMembers}
                         member={selectedMember}
@@ -510,6 +524,9 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                         workflowId={workflowId}
                     />
                 </ModalforAddFlowStepForm>
+            )}
+
+
                 
                 <ModalforAddCheckListForm isOpen={isModalforAddCheckListFormOpen} onClose={closeAddCheckListModal}>
                     <AddCheckListForm

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -126,6 +126,7 @@ const MatrixCol = ({ openAddFlowStepModal, openAddCheckListModal, flowNumber, on
                     <div key={flowstep.id} className="member-cell">
                         <FlowStep
                             flowstep={flowstep}
+                            flowNumber={flowNumber}
                             workflowId={workflowId}
                         />
                     </div>

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -1,10 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+// Store Redux Sliceのインポート
 import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSlice';
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { fetchCheckLists, selectCheckListsByColumn } from '../store/checklistSlice';
+import { openCheckListModal } from '../store/modalSlice';
+
+// FontAwesomeのアイコンのインポート
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser, faSquarePlus, faArrowUp, faArrowDown, faTrash, faEdit, faRoadBarrier, faPlus, faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
+
+// コンポーネントのインポート
 import FlowStep from '../Components/Flowstep';
 import AddMemberForm from '../Components/AddMemberForm';
 import AddFlowStepForm from '../Components/AddFlowStepForm';
@@ -15,9 +22,15 @@ import CheckListModal from '../Components/CheckListModal';
 import CheckListModalContent from '../Components/CheckListModalContent';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+
+// スタイル
 import '../../css/MatrixView.css';
 
+
+// コンポーネントの定義
 const CheckItemColumn = ({ member, flowNumber, openAddCheckListModal, workflowId }) => {
+    const dispatch = useDispatch();
+
     const checkListsFromStore = useSelector(selectCheckListsByColumn);
     const checkListsForFlowNumber = checkListsFromStore[flowNumber] || [];
     
@@ -28,8 +41,7 @@ const CheckItemColumn = ({ member, flowNumber, openAddCheckListModal, workflowId
     console.log("hasCheckList:", hasCheckList);
 
     const handleCheckListClick = (checklist) => {
-        setSelectedCheckList(checklist); // 選択されたチェックリストを設定
-        setIsModalOpen(true); // モーダルを開く
+        dispatch(openCheckListModal({ checkList: checklist }));
     };
 
     const closeModal = () => {
@@ -292,6 +304,7 @@ const MatrixRow = ({
 
 const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflowId }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const { isAddFlowStepModalOpen } = useSelector((state) => state.modal);
     const [isModalforAddCheckListFormOpen, setIsModalforAddCheckListFormOpen] = useState(false);
     const [selectedMember, setSelectedMember] = useState(null);
     const [selectedStepNumber, setSelectedStepNumber] = useState(null);

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -6,6 +6,8 @@ import { fetchMembers, updateMemberName, deleteMember } from '../store/memberSli
 import { fetchFlowsteps, updateFlowStepNumber } from '../store/flowstepsSlice';
 import { fetchCheckLists, selectCheckListsByColumn } from '../store/checklistSlice';
 import { openCheckListModal, openAddFlowstepModal } from '../store/modalSlice';
+import { setSelectedMember, setSelectedStepNumber } from '../store/selectedSlice';
+
 
 // FontAwesomeのアイコンのインポート
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -154,6 +156,14 @@ const MatrixRow = ({
     const [isEditing, setIsEditing] = useState(false);
     const [newName, setNewName] = useState(member.name);
     const [checkLists, setCheckLists] = useState({}); // チェックリストの状態管理
+
+    const selectedMember = useSelector((state) => state.selected.selectedMember);
+    const selectedStepNumber = useSelector((state) => state.selected.selectedStepNumber);
+      // 状態をコンソールに表示
+    console.log('selectedMember:', selectedMember);
+    console.log('selectedStepNumber:', selectedStepNumber);
+
+  
     const dispatch = useDispatch();
     
     // Reduxからチェックリストを取得
@@ -174,8 +184,10 @@ const MatrixRow = ({
     }, [checkListsFromStore]);
 
     const isAddFlowstepModalOpen = useSelector(state => state.modal.isAddFlowstepModalOpen);
-    const handleOpenAddFlowstepModal = (member, selectedStepNumber) => {
-        dispatch(openAddFlowstepModal(member, selectedStepNumber));
+    const handleOpenAddFlowstepModal = (member, stepNumber) => {
+        dispatch(setSelectedMember(member));
+        dispatch(setSelectedStepNumber(stepNumber));
+        dispatch(openAddFlowstepModal(member, stepNumber));
     };
 
 

--- a/src/resources/js/Components/ModalforAddFlowStepForm.jsx
+++ b/src/resources/js/Components/ModalforAddFlowStepForm.jsx
@@ -1,13 +1,22 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { closeAddFlowstepModal } from '../store/modalSlice';
 import '../../css/ModalforAddFlowStepForm.css';
 
 const ModalforAddFlowStepForm = ({ isOpen, onClose, children }) => {
-    if (!isOpen) return null; // モーダルが開いていない場合は何も表示しない
+    const dispatch = useDispatch();
+    
+    const isAddFlowstepModalOpen = useSelector(state => state.modal.isAddFlowstepModalOpen);
+    const handleCloseAddFlowstepModal = (member, selectedStepNumber) => {
+        dispatch(closeAddFlowstepModal(member, selectedStepNumber));
+    };
+    
+    if (!isAddFlowstepModalOpen) return null; // モーダルが開いていない場合は何も表示しない
 
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-                <button className="modal-close" onClick={onClose}>×</button>
+                <button className="modal-close" onClick={handleCloseAddFlowstepModal}>×</button>
                 {children}
             </div>
         </div>

--- a/src/resources/js/Components/ModalforUpdateFlowStepForm.jsx
+++ b/src/resources/js/Components/ModalforUpdateFlowStepForm.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { closeUpdateFlowstepModal } from '../store/modalSlice';
+import '../../css/ModalforAddFlowStepForm.css';
+
+const ModalforUpdateFlowStepForm = ({ isOpen, onClose, children }) => {
+    const dispatch = useDispatch();
+    
+    const isUpdateFlowstepModalOpen = useSelector(state => state.modal.isUpdateFlowstepModalOpen);
+    const handleCloseUpdateFlowstepModal = (member, selectedStepNumber) => {
+        dispatch(closeUpdateFlowstepModal(member, selectedStepNumber));
+    };
+    
+    if (!isUpdateFlowstepModalOpen) return null; // モーダルが開いていない場合は何も表示しない
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={handleCloseUpdateFlowstepModal}>×</button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default ModalforUpdateFlowStepForm;

--- a/src/resources/js/Components/UpdateFlowStepForm.jsx
+++ b/src/resources/js/Components/UpdateFlowStepForm.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { addFlowstep, deleteFlowstepAsync, fetchFlowsteps } from '../store/flowstepsSlice'; // Adjust the import path as needed
+import '../../css/AddFlowStepForm.css';
+
+const UpdateFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {
+    const [name, setName] = useState(''); 
+    const [error, setError] = useState(null);
+    const [flowNumber, setFlowNumber] = useState(stepNumber); 
+    const [selectedMembers, setSelectedMembers] = useState([]); 
+    const [searchTerm, setSearchTerm] = useState(''); 
+    
+    const selectedMember = useSelector((state) => state.selected.selectedMember);
+    const selectedStepNumber = useSelector((state) => state.selected.selectedStepNumber);
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (selectedMember) {
+            setSelectedMembers([selectedMember.id]);
+        }
+        if (stepNumber) {
+            setFlowNumber(stepNumber);
+        }
+    }, [selectedMember, stepNumber]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError(null);
+    
+        const flowstepData = {
+            name: name,
+            flow_number: flowNumber || selectedStepNumber, // flow_number が設定されていない場合は selectedStepNumber を使用
+            member_id: selectedMembers,
+            step_number: selectedStepNumber,
+        };
+        console.log('Sending data:', flowstepData, 'to workflowId:', workflowId); // データ確認用
+    
+        try {
+            const action = await dispatch(addFlowstep({ workflowId, newFlowstep: flowstepData })).unwrap();
+            setName('');
+            console.log('Flowstep added:', action);
+            dispatch(fetchFlowsteps(workflowId));
+        } catch (error) {
+            console.error('Error adding Flowstep:', error);
+            setError('Failed to add Flowstep.');
+        }
+    };
+    
+    const handleDelete = (id) => {
+        dispatch(deleteFlowstepAsync(id));
+    };
+
+    const handleMemberChange = (e) => {
+        const options = e.target.options;
+        const value = [];
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected) {
+                value.push(options[i].value);
+            }
+        }
+        setSelectedMembers(value);
+    };
+
+    const handleStepChange = (e) => {
+        setFlowNumber(e.target.value);
+    };
+
+    const filteredMembers = members.filter((m) => 
+        m.name.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    return (
+        <div>
+            <form className="form-container" onSubmit={handleSubmit}>
+                <div>
+                    <label>フローステップ名:</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)} 
+                        required
+                        placeholder="担当者がフローとして行うことを入力しましょう"
+                    />
+                </div>
+                <div>
+                    <label>ステップNo.:</label>
+                    <select
+                        value={flowNumber}
+                        onChange={handleStepChange}
+                        required
+                    >
+                        {Array.from({ length: nextStepNumber }, (_, index) => (
+                            <option key={index + 1} value={index + 1}>
+                                STEP {index + 1}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label>担当者を検索:</label>
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder="担当者を名前検索できます"
+                    />
+                </div>
+                <div>
+                    <label>担当者を選択:</label>
+                    <select
+                        multiple
+                        value={selectedMembers}
+                        onChange={handleMemberChange}
+                        required
+                    >
+                        {filteredMembers.length > 0 ? (
+                            filteredMembers.map((m) => (
+                                <option key={m.id} value={m.id}>
+                                    {m.name}
+                                </option>
+                            ))
+                        ) : (
+                            <option disabled>No members available</option>
+                        )}
+                    </select>
+                </div>
+                <button type="submit">フローステップを追加</button>
+            </form>
+        </div>
+    );
+};
+
+export default UpdateFlowStepForm;

--- a/src/resources/js/Components/UpdateFlowStepForm.jsx
+++ b/src/resources/js/Components/UpdateFlowStepForm.jsx
@@ -1,56 +1,61 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { addFlowstep, deleteFlowstepAsync, fetchFlowsteps } from '../store/flowstepsSlice'; // Adjust the import path as needed
+import { updateFlowstep, deleteFlowstepAsync, fetchFlowsteps } from '../store/flowstepsSlice'; // インポートパスを適宜調整
 import '../../css/AddFlowStepForm.css';
 
-const UpdateFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member = null, stepNumber = '', nextStepNumber, workflowId }) => {
-    const [name, setName] = useState(''); 
+const UpdateFlowStepForm = ({ members = [], nextStepNumber, workflowId }) => {
+    const [name, setName] = useState('');
     const [error, setError] = useState(null);
-    const [flowNumber, setFlowNumber] = useState(stepNumber); 
-    const [selectedMembers, setSelectedMembers] = useState([]); 
-    const [searchTerm, setSearchTerm] = useState(''); 
-    
-    const selectedMember = useSelector((state) => state.selected.selectedMember);
-    const selectedStepNumber = useSelector((state) => state.selected.selectedStepNumber);
+    const [flowNumber, setFlowNumber] = useState('');
+    const [selectedMembers, setSelectedMembers] = useState([]);
+    const [searchTerm, setSearchTerm] = useState('');
 
     const dispatch = useDispatch();
 
-    useEffect(() => {
-        if (selectedMember) {
-            setSelectedMembers([selectedMember.id]);
-        }
-        if (stepNumber) {
-            setFlowNumber(stepNumber);
-        }
-    }, [selectedMember, stepNumber]);
+    // Reduxから選択されたメンバーとフローステップの状態を取得
+    const selectedMember = useSelector((state) => state.selected.selectedMember);
+    const selectedStepNumber = useSelector((state) => state.selected.selectedStepNumber);
+    const selectedFlowstep = useSelector((state) => state.selected.selectedFlowstep);
 
+    // デバッグ用ログ
+    console.log('selectedMember on UpdateFlowStepForm.jsx:', selectedMember);
+    console.log('selectedFlowstep on UpdateFlowStepForm.jsx:', selectedFlowstep);
+    console.log('selectedStepNumber on UpdateFlowStepForm.jsx:', selectedStepNumber);
+
+    // `flowstep`が渡された場合、初期値を設定
+    useEffect(() => {
+        if (selectedFlowstep) {
+            setName(selectedFlowstep.name);
+            setFlowNumber(selectedFlowstep.flow_number);
+            setSelectedMembers(selectedFlowstep.member_id); 
+        }
+    }, [selectedFlowstep]);
+
+    // フローステップを更新するためのフォーム送信処理
     const handleSubmit = async (e) => {
         e.preventDefault();
         setError(null);
-    
+
         const flowstepData = {
+            id: selectedFlowstep.id, // 既存のIDを含める
             name: name,
-            flow_number: flowNumber || selectedStepNumber, // flow_number が設定されていない場合は selectedStepNumber を使用
+            flow_number: selectedFlowstep.flow_number, // フローステップの番号はフォームの値か、選択されたステップ番号を使用
             member_id: selectedMembers,
-            step_number: selectedStepNumber,
+            step_number: selectedFlowstep?.flow_number, // `step_number`は適切に処理
         };
-        console.log('Sending data:', flowstepData, 'to workflowId:', workflowId); // データ確認用
-    
+        console.log('更新するデータ:', flowstepData, 'workflowId:', workflowId);
+
         try {
-            const action = await dispatch(addFlowstep({ workflowId, newFlowstep: flowstepData })).unwrap();
-            setName('');
-            console.log('Flowstep added:', action);
-            dispatch(fetchFlowsteps(workflowId));
+            const action = await dispatch(updateFlowstep({ workflowId, updatedFlowstep: flowstepData })).unwrap();
+            console.log('フローステップが更新されました:', action);
+            dispatch(fetchFlowsteps(workflowId)); // 更新されたフローステップを取得
         } catch (error) {
-            console.error('Error adding Flowstep:', error);
-            setError('Failed to add Flowstep.');
+            console.error('フローステップの更新エラー:', error);
+            setError('フローステップの更新に失敗しました。');
         }
     };
-    
-    const handleDelete = (id) => {
-        dispatch(deleteFlowstepAsync(id));
-    };
 
+    // メンバー選択処理
     const handleMemberChange = (e) => {
         const options = e.target.options;
         const value = [];
@@ -62,11 +67,13 @@ const UpdateFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member =
         setSelectedMembers(value);
     };
 
+    // フローステップ番号の変更処理
     const handleStepChange = (e) => {
         setFlowNumber(e.target.value);
     };
 
-    const filteredMembers = members.filter((m) => 
+    // メンバーのフィルタリング
+    const filteredMembers = members.filter((m) =>
         m.name.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
@@ -121,12 +128,13 @@ const UpdateFlowStepForm = ({ members = [], onFlowStepAdded = () => {}, member =
                                 </option>
                             ))
                         ) : (
-                            <option disabled>No members available</option>
+                            <option disabled>メンバーが利用できません</option>
                         )}
                     </select>
                 </div>
-                <button type="submit">フローステップを追加</button>
+                <button type="submit">フローステップを更新</button>
             </form>
+            {error && <p>{error}</p>}
         </div>
     );
 };

--- a/src/resources/js/Components/UpdateFlowStepForm.jsx
+++ b/src/resources/js/Components/UpdateFlowStepForm.jsx
@@ -27,10 +27,13 @@ const UpdateFlowStepForm = ({ members = [], nextStepNumber, workflowId }) => {
         if (selectedFlowstep) {
             setName(selectedFlowstep.name);
             setFlowNumber(selectedFlowstep.flow_number);
-            setSelectedMembers(selectedFlowstep.member_id); 
         }
-    }, [selectedFlowstep]);
-
+        if (selectedMember) {
+            setSelectedMembers([selectedMember.id]);
+        }
+        console.log("selectedMembers:", selectedMembers);
+    }, [selectedFlowstep, selectedMember]);
+    
     // フローステップを更新するためのフォーム送信処理
     const handleSubmit = async (e) => {
         e.preventDefault();

--- a/src/resources/js/store/flowstepsSlice.js
+++ b/src/resources/js/store/flowstepsSlice.js
@@ -95,11 +95,11 @@ export const assignFlowStep = createAsyncThunk(
 );
 
 // FlowStepを編集するアクション
-export const updateFlowstepAsync = createAsyncThunk(
-  'flowsteps/updateFlowstep',
+export const updateFlowstepName = createAsyncThunk(
+  'flowsteps/updateFlowstepName',
   async ({ id, updatedFlowstep }, { dispatch, rejectWithValue }) => {
     try {
-      const response = await axios.put(`/api/flowsteps/${id}`, updatedFlowstep, {
+      const response = await axios.put(`/api/flowsteps/update-name/${id}`, updatedFlowstep, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/resources/js/store/flowstepsSlice.js
+++ b/src/resources/js/store/flowstepsSlice.js
@@ -95,6 +95,31 @@ export const assignFlowStep = createAsyncThunk(
 );
 
 // FlowStepを編集するアクション
+export const updateFlowstep = createAsyncThunk(
+  'flowsteps/updateFlowstep',
+  async ({ updatedFlowstep }, { dispatch, rejectWithValue }) => {
+    try {
+      // flowNumber を flow_number に変更
+      const response = await axios.put(`/api/flowsteps/${updatedFlowstep.id}`, {
+        ...updatedFlowstep,
+        flow_number: updatedFlowstep.flow_number // flow_number にリネーム
+      }, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      dispatch(flowstepsSlice.actions.editFlowstep({ id: updatedFlowstep.id, updatedFlowstep: response.data }));
+      
+      return response.data;
+
+    } catch (error) {
+      return rejectWithValue(error.response?.data?.message || error.message);
+    }
+  }
+);
+
+// FlowStepを編集するアクション
 export const updateFlowstepName = createAsyncThunk(
   'flowsteps/updateFlowstepName',
   async ({ id, updatedFlowstep }, { dispatch, rejectWithValue }) => {

--- a/src/resources/js/store/flowstepsSlice.js
+++ b/src/resources/js/store/flowstepsSlice.js
@@ -98,29 +98,20 @@ export const assignFlowStep = createAsyncThunk(
 export const updateFlowstepAsync = createAsyncThunk(
   'flowsteps/updateFlowstep',
   async ({ id, updatedFlowstep }, { dispatch, rejectWithValue }) => {
-
     try {
-      const response = await axios.put(`/api/flowsteps/${id}`, {
-        method: 'PUT',
+      const response = await axios.put(`/api/flowsteps/${id}`, updatedFlowstep, {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(updatedFlowstep),
       });
 
-      if (!response.ok) {
-        throw new Error('Failed to edit FlowStep');
-      }
-
-      const data = await response.json();
-      
       // 成功した場合はstateを更新するアクションをdispatch
-      dispatch(flowstepsSlice.actions.editFlowstep({ id, updatedFlowstep: data }));
+      dispatch(flowstepsSlice.actions.editFlowstep({ id, updatedFlowstep: response.data }));
       
-      return data;
+      return response.data;
 
     } catch (error) {
-      return rejectWithValue(error.message);
+      return rejectWithValue(error.response?.data?.message || error.message);
     }
   }
 );

--- a/src/resources/js/store/modalSlice.js
+++ b/src/resources/js/store/modalSlice.js
@@ -1,0 +1,51 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  isCheckListModalOpen: false,
+  isOpenModalforAddFlowStepForm: false,
+  selectedCheckList: null,
+  selectedMember: null,
+  selectedStepNumber: null,
+};
+
+const modalSlice = createSlice({
+  name: 'modal',
+  initialState,
+  reducers: {
+    openCheckListModal: (state, action) => {
+      state.isCheckListModalOpen = true;
+      state.selectedCheckList = action.payload.checkList;
+    },
+    closeCheckListModal: (state) => {
+      state.isCheckListModalOpen = false;
+      state.selectedCheckList = null;
+    },
+    openAddFlowStepModal: (state, action) => {
+      state.isAddFlowStepModalOpen = true;
+      state.selectedMember = action.payload.member;
+      state.selectedStepNumber = action.payload.stepNumber;
+    },
+    closeAddFlowStepModal: (state) => {
+      state.isAddFlowStepModalOpen = false;
+      state.selectedMember = null;
+      state.selectedStepNumber = null;
+    },
+    openModalforAddFlowStepForm: (state) => { // 追加
+      state.isOpenModalforAddFlowStepForm = true;
+    },
+    closeModalforAddFlowStepForm: (state) => { // 追加
+      state.isOpenModalforAddFlowStepForm = false;
+    },
+  },
+});
+
+export const {
+  openCheckListModal,
+  closeCheckListModal,
+  openAddFlowStepModal,
+  closeAddFlowStepModal,
+  openModalforAddFlowStepForm, // 追加
+  closeModalforAddFlowStepForm, // 追加
+} = modalSlice.actions;
+
+export default modalSlice.reducer;

--- a/src/resources/js/store/modalSlice.js
+++ b/src/resources/js/store/modalSlice.js
@@ -3,9 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const initialState = {
   isCheckListModalOpen: false,
   isAddFlowstepModalOpen: false,
-  selectedCheckList: null,
-  selectedMember: null,
-  selectedStepNumber: null,
+  isUpdateFlowstepModalOpen: false,
 };
 
 const modalSlice = createSlice({
@@ -22,13 +20,15 @@ const modalSlice = createSlice({
     },
     openAddFlowstepModal: (state, action) => {
       state.isAddFlowstepModalOpen = true;
-      state.selectedMember = action.payload.member;
-      state.selectedStepNumber = action.payload.stepNumber;
     },
     closeAddFlowstepModal: (state) => {
       state.isAddFlowstepModalOpen = false;
-      state.selectedMember = null;
-      state.selectedStepNumber = null;
+    },
+    openUpdateFlowstepModal: (state, action) => {
+      state.isUpdateFlowstepModalOpen = true;
+    },
+    closeUpdateFlowstepModal: (state) => {
+      state.isUpdateFlowstepModalOpen = false;
     }
   },
 });
@@ -38,6 +38,8 @@ export const {
   closeCheckListModal,
   openAddFlowstepModal,
   closeAddFlowstepModal,
+  openUpdateFlowstepModal,
+  closeUpdateFlowstepModal,
 } = modalSlice.actions;
 
 export default modalSlice.reducer;

--- a/src/resources/js/store/modalSlice.js
+++ b/src/resources/js/store/modalSlice.js
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   isCheckListModalOpen: false,
-  isOpenModalforAddFlowStepForm: false,
+  isAddFlowstepModalOpen: false,
   selectedCheckList: null,
   selectedMember: null,
   selectedStepNumber: null,
@@ -20,32 +20,24 @@ const modalSlice = createSlice({
       state.isCheckListModalOpen = false;
       state.selectedCheckList = null;
     },
-    openAddFlowStepModal: (state, action) => {
-      state.isAddFlowStepModalOpen = true;
+    openAddFlowstepModal: (state, action) => {
+      state.isAddFlowstepModalOpen = true;
       state.selectedMember = action.payload.member;
       state.selectedStepNumber = action.payload.stepNumber;
     },
-    closeAddFlowStepModal: (state) => {
-      state.isAddFlowStepModalOpen = false;
+    closeAddFlowstepModal: (state) => {
+      state.isAddFlowstepModalOpen = false;
       state.selectedMember = null;
       state.selectedStepNumber = null;
-    },
-    openModalforAddFlowStepForm: (state) => { // 追加
-      state.isOpenModalforAddFlowStepForm = true;
-    },
-    closeModalforAddFlowStepForm: (state) => { // 追加
-      state.isOpenModalforAddFlowStepForm = false;
-    },
+    }
   },
 });
 
 export const {
   openCheckListModal,
   closeCheckListModal,
-  openAddFlowStepModal,
-  closeAddFlowStepModal,
-  openModalforAddFlowStepForm, // 追加
-  closeModalforAddFlowStepForm, // 追加
+  openAddFlowstepModal,
+  closeAddFlowstepModal,
 } = modalSlice.actions;
 
 export default modalSlice.reducer;

--- a/src/resources/js/store/selectedSlice.js
+++ b/src/resources/js/store/selectedSlice.js
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  selectedMember: null,  // 初期状態ではnullに設定
+  selectedStepNumber: null,  // 初期状態ではnullに設定
+};
+
+const selectedSlice = createSlice({
+  name: 'selected',
+  initialState,
+  reducers: {
+    setSelectedMember: (state, action) => {
+      state.selectedMember = action.payload;
+    },
+    setSelectedStepNumber: (state, action) => {
+      state.selectedStepNumber = action.payload;
+    },
+  },
+});
+
+export const { setSelectedMember, setSelectedStepNumber } = selectedSlice.actions;
+
+export default selectedSlice.reducer;

--- a/src/resources/js/store/selectedSlice.js
+++ b/src/resources/js/store/selectedSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   selectedMember: null,  // 初期状態ではnullに設定
+  selectedFlowstep: null,  // 初期状態ではnullに設定
   selectedStepNumber: null,  // 初期状態ではnullに設定
 };
 
@@ -12,12 +13,15 @@ const selectedSlice = createSlice({
     setSelectedMember: (state, action) => {
       state.selectedMember = action.payload;
     },
+    setSelectedFlowstep: (state, action) => {
+      state.selectedFlowstep = action.payload;
+    },
     setSelectedStepNumber: (state, action) => {
       state.selectedStepNumber = action.payload;
     },
   },
 });
 
-export const { setSelectedMember, setSelectedStepNumber } = selectedSlice.actions;
+export const { setSelectedMember, setSelectedFlowstep, setSelectedStepNumber } = selectedSlice.actions;
 
 export default selectedSlice.reducer;

--- a/src/resources/js/store/store.js
+++ b/src/resources/js/store/store.js
@@ -4,6 +4,7 @@ import flowstepsReducer from './flowstepsSlice';
 import checklistsReducer from './checklistSlice';
 import workflowReducer from './workflowSlice';
 import modalReducer from './modalSlice';
+import selectedReducer from './selectedSlice';
 import memberReducerForGuest from './memberSliceForGuest';
 
 
@@ -14,6 +15,7 @@ const store = configureStore({
         checkLists: checklistsReducer,
         workflow: workflowReducer,
         modal: modalReducer,
+        selected: selectedReducer,
         membersForGuest: memberReducerForGuest
     },
 });

--- a/src/resources/js/store/store.js
+++ b/src/resources/js/store/store.js
@@ -3,8 +3,8 @@ import memberReducer from './memberSlice';
 import flowstepsReducer from './flowstepsSlice';
 import checklistsReducer from './checklistSlice';
 import workflowReducer from './workflowSlice';
+import modalReducer from './modalSlice';
 import memberReducerForGuest from './memberSliceForGuest';
-import workflowSlice from './workflowSlice';
 
 
 const store = configureStore({
@@ -13,6 +13,7 @@ const store = configureStore({
         flowsteps: flowstepsReducer,
         checkLists: checklistsReducer,
         workflow: workflowReducer,
+        modal: modalReducer,
         membersForGuest: memberReducerForGuest
     },
 });

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -39,7 +39,7 @@ Route::get('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class, 
 Route::post('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class, 'store']);
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);
-Route::put('/api/flowsteps/{id}', [FlowStepController::class, 'update']);
+Route::put('/api/flowsteps/update-name/{id}', [FlowstepController::class, 'updateName']);
 
 
 use App\Http\Controllers\FlowstepMemberController;

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -40,6 +40,7 @@ Route::post('/api/workflows/{workflowId}/flowsteps', [FlowstepController::class,
 Route::post('/api/update-flowstep-stepnumber', [FlowstepController::class, 'updateFlowstepStepnumber']);
 Route::delete('/api/flowsteps/{id}', [FlowstepController::class, 'destroy']);
 Route::put('/api/flowsteps/update-name/{id}', [FlowstepController::class, 'updateName']);
+Route::put('/api/flowsteps/{id}', [FlowstepController::class, 'update']);
 
 
 use App\Http\Controllers\FlowstepMemberController;


### PR DESCRIPTION
## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
 - Laravel
   - Flowstepの更新に関するアクションを区別するための名前変更・新規作成
     - Flowstepからそのまま名前のみを変更するアクション
       -  アクション名の変更： `update`→`updateName`  
       -  ルーティングの変更：`/api/flowsteps/{id}` → `/api/flowsteps/update-name/{id}`
     - Flowstep更新用モーダルを開き、Flowstepを更新するアクション（新規作成）
       -  アクション名： `update`  
       -  ルーティングの変更：`/api/flowsteps/{id}`
 - React
   - モーダルの開閉状態の制御をRedux Slice化 (`modelSlice`)
   - MatrixViewの選択中の行・列に依存する選択中のmember / flowstep / flowNumber をRedux Slice化 (`selectedSlice`)

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Redux化することにより状態のコンポーネント間の受け渡しを無くした

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
