### PR TITLE
Feature_2024.11.10.17.12_Documentコンポーネント上のChecklistの表示・非表示を切り替えれるように実装する

### DIFF
--- a/src/resources/css/Document.css
+++ b/src/resources/css/Document.css
@@ -1,6 +1,11 @@
 .document-container {
 }
 
+.settings-button {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .document-title {
   font-size: 18px; /* 見出しのフォントサイズ */
   font-weight: bold;

--- a/src/resources/css/DocumentSettingsForm.css
+++ b/src/resources/css/DocumentSettingsForm.css
@@ -1,0 +1,7 @@
+.document-settings-checklist-visible {
+  display: flex;
+}
+
+.document-setting-item {
+  margin-left: 10px;
+}

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -1,16 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+// Redux Slice Storeの参照
 import { fetchFlowsteps } from '../store/flowstepsSlice';
 import { fetchCheckLists, updateChecklist, deleteChecklist } from '../store/checklistSlice';
 import { fetchWorkflow } from '../store/workflowSlice';
+import { openDocumentSettingsModal } from '../store/modalSlice';
+
+// Font Awesome アイコンの設定
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faClipboardCheck, faEdit, faSave, faCancel, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faClipboardCheck, faEdit, faSave, faCancel, faTrash, faCog } from '@fortawesome/free-solid-svg-icons';
+
+// スタイル
 import '../../css/Document.css';
 
 const Document = ({ workflowId }) => {
   const dispatch = useDispatch();
   const [editingChecklist, setEditingChecklist] = useState(null);
   const [updatedChecklistName, setUpdatedChecklistName] = useState('');
+  const [showChecklists, setShowChecklists] = useState(true); // 新規：チェックリスト表示・非表示用のステート
 
   const { workflows, loading, error } = useSelector((state) => state.workflow);
   const flowsteps = useSelector((state) => state.flowsteps);
@@ -45,19 +53,33 @@ const Document = ({ workflowId }) => {
     dispatch(fetchCheckLists(workflowId));
   };
 
-  // 新規：削除ボタン用の関数
   const handleDeleteClick = (checklist) => {
     dispatch(deleteChecklist({
-      // workflowId,
       checklistId: checklist.id,
     }));
   };
 
   const workflowName = workflows[0]?.name;
 
+  const handleOpenDocumentSettingsModal = () => {
+    dispatch(openDocumentSettingsModal());
+  }
+
+  // 新規：表示・非表示トグル用の関数
+  // const toggleChecklistsVisibility = () => {
+  //   setShowChecklists((prev) => !prev);
+  // };
+
   return (
     <div className="document-container">
-      <div className="document-title">{workflowName ? workflowName : 'ワークフローが見つかりません。'}</div>
+      <div className="settings-button">
+        <button onClick={handleOpenDocumentSettingsModal}>
+          <FontAwesomeIcon icon={faCog} />
+        </button>
+      </div>
+      <div className="document-title">
+        {workflowName ? workflowName : 'ワークフローが見つかりません。'}
+      </div>
 
       {flowsteps.length === 0 ? (
         <p>フローステップはまだありません。</p>
@@ -75,49 +97,51 @@ const Document = ({ workflowId }) => {
                 {flowstep.content}
               </div>
 
-              <div className="checklist-container-card">
-                <div className="checklist-title">チェック項目</div>
-                {flowstepChecklists.length > 0 ? (
-                  <ul className="checklist-container">
-                    {flowstepChecklists.map((checklist) => (
-                      <li key={checklist.id} className="checklist-card">
-                        <FontAwesomeIcon icon={faClipboardCheck} className="icon-on-checklist-card" />
-                        {editingChecklist === checklist.id ? (
-                          <div>
-                            <input
-                              type="text"
-                              value={updatedChecklistName}
-                              onChange={(e) => setUpdatedChecklistName(e.target.value)}
-                            />
-                            <button onClick={() => handleSaveClick(checklist)}>
-                              <FontAwesomeIcon icon={faSave} className="faSave-icon-on-checklist-card" />
-                            </button>
-                            <button onClick={() => setEditingChecklist(null)}>
-                              <FontAwesomeIcon icon={faCancel} className="faCancel-icon-on-checklist-card" />
-                            </button>
-                          </div>
-                        ) : (
-                          <div className="checklist-name-and-icon-container">
-                            <div className="checklist-name">
-                              {checklist.name}
-                            </div>
+              {showChecklists && ( // showChecklists の状態で表示を切り替え
+                <div className="checklist-container-card">
+                  <div className="checklist-title">チェック項目</div>
+                  {flowstepChecklists.length > 0 ? (
+                    <ul className="checklist-container">
+                      {flowstepChecklists.map((checklist) => (
+                        <li key={checklist.id} className="checklist-card">
+                          <FontAwesomeIcon icon={faClipboardCheck} className="icon-on-checklist-card" />
+                          {editingChecklist === checklist.id ? (
                             <div>
-                              <button onClick={() => handleEditClick(checklist)}>
-                                <FontAwesomeIcon icon={faEdit} className="faEdit-icon-on-checklist-card" />
+                              <input
+                                type="text"
+                                value={updatedChecklistName}
+                                onChange={(e) => setUpdatedChecklistName(e.target.value)}
+                              />
+                              <button onClick={() => handleSaveClick(checklist)}>
+                                <FontAwesomeIcon icon={faSave} className="faSave-icon-on-checklist-card" />
                               </button>
-                              <button onClick={() => handleDeleteClick(checklist)}>
-                                <FontAwesomeIcon icon={faTrash} className="faTrash-icon-on-checklist-card" />
+                              <button onClick={() => setEditingChecklist(null)}>
+                                <FontAwesomeIcon icon={faCancel} className="faCancel-icon-on-checklist-card" />
                               </button>
                             </div>
-                          </div>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <div className="non-flowstep-message-on-document">チェック項目はありません。</div>
-                )}
-              </div>
+                          ) : (
+                            <div className="checklist-name-and-icon-container">
+                              <div className="checklist-name">
+                                {checklist.name}
+                              </div>
+                              <div>
+                                <button onClick={() => handleEditClick(checklist)}>
+                                  <FontAwesomeIcon icon={faEdit} className="faEdit-icon-on-checklist-card" />
+                                </button>
+                                <button onClick={() => handleDeleteClick(checklist)}>
+                                  <FontAwesomeIcon icon={faTrash} className="faTrash-icon-on-checklist-card" />
+                                </button>
+                              </div>
+                            </div>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="non-flowstep-message-on-document">チェック項目はありません。</div>
+                  )}
+                </div>
+              )}
             </div>
           );
         })

--- a/src/resources/js/Components/DocumentSettingsForm.jsx
+++ b/src/resources/js/Components/DocumentSettingsForm.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import '../../css/DocumentSettingsForm.css'
+
+const DocumentSettingsForm = ({ showChecklists, setShowChecklists }) => {
+  const handleCheckboxChange = (e) => {
+    setShowChecklists(e.target.checked);
+  };
+
+  return (
+    <div className="document-settings-form">
+      <div className="document-settings-checklist-visible">
+            <div>
+                <input 
+                type="checkbox" 
+                checked={showChecklists} 
+                onChange={handleCheckboxChange} 
+                />
+            </div>
+            <div className="document-setting-item">
+                チェックリストを表示する
+            </div>
+      </div>
+    </div>
+  );
+};
+
+export default DocumentSettingsForm;

--- a/src/resources/js/Components/MatrixView.jsx
+++ b/src/resources/js/Components/MatrixView.jsx
@@ -457,7 +457,7 @@ const MatrixView = ({ onAssignFlowStep, onMemberAdded, onFlowStepAdded, workflow
                     <table className="matrix-table">
                         <thead>
                             <tr>
-                                <th className="matrix-corner-header">Members / FlowStep</th>
+                                <th className="matrix-corner-header">担当者 / フローステップ</th>
                                 {Array.from({ length: maxFlowNumber }, (_, i) => i + 1).map((flowNumber) => (
                                     <th key={flowNumber} className="matrix-header">STEP {flowNumber}</th>
                                 ))}

--- a/src/resources/js/Components/ModalforDocumentSettings.jsx
+++ b/src/resources/js/Components/ModalforDocumentSettings.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import '../../css/ModalforAddCheckListForm.css';
+import { closeDocumentSettingsModal } from '../store/modalSlice';
+import { useDispatch } from 'react-redux';
+
+
+const ModalforDocumentSettings = ({ onClose, children }) => {
+    const dispatch = useDispatch();
+
+    const handleCloseDocumentSettingsModal = () => {
+        dispatch(closeDocumentSettingsModal());
+    }
+
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={handleCloseDocumentSettingsModal}>×</button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default ModalforDocumentSettings;

--- a/src/resources/js/Pages/CreateMatrixFlowPage.jsx
+++ b/src/resources/js/Pages/CreateMatrixFlowPage.jsx
@@ -1,12 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+// Redux Slice Storeの読み込み
 import { fetchMembers } from '../store/memberSlice'; 
 import { fetchFlowsteps, assignFlowStep } from '../store/flowstepsSlice'; 
+
+// コンポーネントの読み込み
 import MatrixView from '../Components/MatrixView';
 import Document from '../Components/Document';
+import ModalforDocumentSettings from '../Components/ModalforDocumentSettings';
+import DocumentSettingsForm from '../Components/DocumentSettingsForm';
 import FlashMessage from '../Components/FlashMessage';
+
+// スタイル
 import '../../css/CreateMatrixFlowPage.css';
-import AuthenticatedLayout from '../Layouts/AuthenticatedLayout'; 
 
 const CreateMatrixFlowPage = (props) => {
     const dispatch = useDispatch();
@@ -14,9 +21,11 @@ const CreateMatrixFlowPage = (props) => {
     const [membersUpdated, setMembersUpdated] = useState(false);
     const [flowstepsUpdated, setFlowstepsUpdated] = useState(false);
     const [flashMessage, setFlashMessage] = useState('');
+    const [showChecklists, setShowChecklists] = useState(true); 
     const { workflowId } = props;
 
     const members = useSelector((state) => state.members);
+    const isDocumentSettingsModalOpen = useSelector((state) => state.modal.isDocumentSettingsModalOpen);
 
     useEffect(() => {
         dispatch(fetchMembers(workflowId));
@@ -73,6 +82,15 @@ const CreateMatrixFlowPage = (props) => {
                         onFlowStepAdded={handleFlowStepAdded}
                         workflowId={workflowId}
                     />
+
+                    {isDocumentSettingsModalOpen && (
+                        <ModalforDocumentSettings>
+                            <DocumentSettingsForm
+                                showChecklists={showChecklists} 
+                                setShowChecklists={setShowChecklists} 
+                            />
+                        </ModalforDocumentSettings>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/resources/js/store/modalSlice.js
+++ b/src/resources/js/store/modalSlice.js
@@ -4,6 +4,7 @@ const initialState = {
   isCheckListModalOpen: false,
   isAddFlowstepModalOpen: false,
   isUpdateFlowstepModalOpen: false,
+  isDocumentSettingsModalOpen: false,
 };
 
 const modalSlice = createSlice({
@@ -18,17 +19,23 @@ const modalSlice = createSlice({
       state.isCheckListModalOpen = false;
       state.selectedCheckList = null;
     },
-    openAddFlowstepModal: (state, action) => {
+    openAddFlowstepModal: (state) => {
       state.isAddFlowstepModalOpen = true;
     },
     closeAddFlowstepModal: (state) => {
       state.isAddFlowstepModalOpen = false;
     },
-    openUpdateFlowstepModal: (state, action) => {
+    openUpdateFlowstepModal: (state) => {
       state.isUpdateFlowstepModalOpen = true;
     },
     closeUpdateFlowstepModal: (state) => {
       state.isUpdateFlowstepModalOpen = false;
+    },
+    openDocumentSettingsModal: (state) => {
+      state.isDocumentSettingsModalOpen = true;
+    },
+    closeDocumentSettingsModal: (state) => {
+      state.isDocumentSettingsModalOpen = false;
     }
   },
 });
@@ -40,6 +47,8 @@ export const {
   closeAddFlowstepModal,
   openUpdateFlowstepModal,
   closeUpdateFlowstepModal,
+  openDocumentSettingsModal,
+  closeDocumentSettingsModal,
 } = modalSlice.actions;
 
 export default modalSlice.reducer;


### PR DESCRIPTION
## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
 - React
   - Documentコンポーネント上に設定用モーダルを開くための設定ボタンを実装  
   - Document上のChecklistの表示・非表示を切り替えできるように実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Documentコンポーネント上の表示項目を増やすにつれ表示・非表示を切替ができるようにすることが必要

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
