### PR TITLE
Feature 2024.11.10.18.10 documentコンポーネントに関する機能実装

### DIFF
--- a/src/resources/css/Document.css
+++ b/src/resources/css/Document.css
@@ -32,6 +32,10 @@
   margin-bottom: 10px;
 }
 
+.flowstep-description-content {
+  margin-left: 30px;
+}
+
 .chapter h3 {
   font-size: 16px; /* 章の見出しのフォントサイズ */
   color: #555; /* 章見出しの色 */

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -18,12 +18,11 @@ const Document = ({ workflowId }) => {
   const dispatch = useDispatch();
   const [editingChecklist, setEditingChecklist] = useState(null);
   const [updatedChecklistName, setUpdatedChecklistName] = useState('');
-  const [showChecklists, setShowChecklists] = useState(true); // 新規：チェックリスト表示・非表示用のステート
 
   const { workflows, loading, error } = useSelector((state) => state.workflow);
   const flowsteps = useSelector((state) => state.flowsteps);
   const checklists = useSelector((state) => state.checkLists);
-  const showingChecklistsOnDocument = useSelector((state) => state.checkLists.showingChecklistsOnDocument);
+  const showingChecklistsOnDocument = useSelector((state) => state.documentSettings.showingChecklistsOnDocument);
 
   useEffect(() => {
     dispatch(fetchFlowsteps(workflowId));

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -65,11 +65,6 @@ const Document = ({ workflowId }) => {
     dispatch(openDocumentSettingsModal());
   }
 
-  // 新規：表示・非表示トグル用の関数
-  // const toggleChecklistsVisibility = () => {
-  //   setShowChecklists((prev) => !prev);
-  // };
-
   return (
     <div className="document-container">
       <div className="settings-button">
@@ -91,10 +86,14 @@ const Document = ({ workflowId }) => {
             <div key={flowstep.id}>
               <div className="chapter">{index + 1}: {flowstep.name}</div>
               <div className="content">
-                {flowstep.members && flowstep.members.length > 0
-                  ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
-                  : 'Unknown Member が行うタスク:'}
-                {flowstep.content}
+                <div className="main-content">
+                  {flowstep.members && flowstep.members.length > 0
+                    ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
+                    : 'Unknown Member が行うタスク:'}
+                </div>
+                <div className="flowstep-description-content">
+                  {flowstep.description}
+                </div>
               </div>
 
               {showChecklists && ( // showChecklists の状態で表示を切り替え

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -23,6 +23,7 @@ const Document = ({ workflowId }) => {
   const flowsteps = useSelector((state) => state.flowsteps);
   const checklists = useSelector((state) => state.checkLists);
   const showingChecklistsOnDocument = useSelector((state) => state.documentSettings.showingChecklistsOnDocument);
+  const showingFlowstepDescriptionsOnDocument = useSelector((state) => state.documentSettings.showingFlowstepDescriptionsOnDocument);
 
   useEffect(() => {
     dispatch(fetchFlowsteps(workflowId));
@@ -91,9 +92,11 @@ const Document = ({ workflowId }) => {
                     ? `${flowstep.members.map(member => member.name).join(', ')} は${flowstep.name}を行う。`
                     : 'Unknown Member が行うタスク:'}
                 </div>
-                <div className="flowstep-description-content">
-                  {flowstep.description}
-                </div>
+                {showingFlowstepDescriptionsOnDocument && (
+                  <div className="flowstep-description-content">
+                    {flowstep.description}
+                  </div>
+                )}
               </div>
 
               {showingChecklistsOnDocument && ( // showChecklists の状態で表示を切り替え

--- a/src/resources/js/Components/Document.jsx
+++ b/src/resources/js/Components/Document.jsx
@@ -23,6 +23,7 @@ const Document = ({ workflowId }) => {
   const { workflows, loading, error } = useSelector((state) => state.workflow);
   const flowsteps = useSelector((state) => state.flowsteps);
   const checklists = useSelector((state) => state.checkLists);
+  const showingChecklistsOnDocument = useSelector((state) => state.checkLists.showingChecklistsOnDocument);
 
   useEffect(() => {
     dispatch(fetchFlowsteps(workflowId));
@@ -96,7 +97,7 @@ const Document = ({ workflowId }) => {
                 </div>
               </div>
 
-              {showChecklists && ( // showChecklists の状態で表示を切り替え
+              {showingChecklistsOnDocument && ( // showChecklists の状態で表示を切り替え
                 <div className="checklist-container-card">
                   <div className="checklist-title">チェック項目</div>
                   {flowstepChecklists.length > 0 ? (

--- a/src/resources/js/Components/DocumentSettingsForm.jsx
+++ b/src/resources/js/Components/DocumentSettingsForm.jsx
@@ -1,24 +1,33 @@
 import React from 'react';
-import '../../css/DocumentSettingsForm.css'
+import '../../css/DocumentSettingsForm.css';
+import { useDispatch, useSelector } from 'react-redux';
+import { showChecklistsOnDocument, hideChecklistsOnDocument } from '../store/checklistSlice';
 
-const DocumentSettingsForm = ({ showChecklists, setShowChecklists }) => {
+const DocumentSettingsForm = () => {
+  const dispatch = useDispatch();
+  const showChecklists = useSelector((state) => state.checkLists.showingChecklistsOnDocument);
+
   const handleCheckboxChange = (e) => {
-    setShowChecklists(e.target.checked);
+    if (e.target.checked) {
+      dispatch(showChecklistsOnDocument());
+    } else {
+      dispatch(hideChecklistsOnDocument());
+    }
   };
 
   return (
     <div className="document-settings-form">
       <div className="document-settings-checklist-visible">
-            <div>
-                <input 
-                type="checkbox" 
-                checked={showChecklists} 
-                onChange={handleCheckboxChange} 
-                />
-            </div>
-            <div className="document-setting-item">
-                チェックリストを表示する
-            </div>
+        <div>
+          <input 
+            type="checkbox" 
+            checked={showChecklists} 
+            onChange={handleCheckboxChange} 
+          />
+        </div>
+        <div className="document-setting-item">
+          チェックリストを表示する
+        </div>
       </div>
     </div>
   );

--- a/src/resources/js/Components/DocumentSettingsForm.jsx
+++ b/src/resources/js/Components/DocumentSettingsForm.jsx
@@ -1,17 +1,31 @@
 import React from 'react';
 import '../../css/DocumentSettingsForm.css';
 import { useDispatch, useSelector } from 'react-redux';
-import { showChecklistsOnDocument, hideChecklistsOnDocument } from '../store/documentSettingsSlice';
+import { 
+    showChecklistsOnDocument, 
+    hideChecklistsOnDocument,
+    showFlowstepDescriptionsOnDocument,
+    hideFlowstepDescriptionsOnDocument
+ } from '../store/documentSettingsSlice';
 
 const DocumentSettingsForm = () => {
   const dispatch = useDispatch();
   const showChecklists = useSelector((state) => state.documentSettings.showingChecklistsOnDocument);
+  const showFlowstepDescriptions = useSelector((state) => state.documentSettings.showingFlowstepDescriptionsOnDocument);
 
-  const handleCheckboxChange = (e) => {
+  const handleShowChecklistsChange = (e) => {
     if (e.target.checked) {
       dispatch(showChecklistsOnDocument());
     } else {
       dispatch(hideChecklistsOnDocument());
+    }
+  };
+
+  const handleShowFlowstepDescriptionsChange = (e) => {
+    if (e.target.checked) {
+      dispatch(showFlowstepDescriptionsOnDocument());
+    } else {
+      dispatch(hideFlowstepDescriptionsOnDocument());
     }
   };
 
@@ -22,11 +36,23 @@ const DocumentSettingsForm = () => {
           <input 
             type="checkbox" 
             checked={showChecklists} 
-            onChange={handleCheckboxChange} 
+            onChange={handleShowChecklistsChange} 
           />
         </div>
         <div className="document-setting-item">
           チェックリストを表示する
+        </div>
+      </div>
+      <div className="document-settings-checklist-visible">
+        <div>
+          <input 
+            type="checkbox" 
+            checked={showFlowstepDescriptions} 
+            onChange={handleShowFlowstepDescriptionsChange} 
+          />
+        </div>
+        <div className="document-setting-item">
+          フローステップの詳細を表示する
         </div>
       </div>
     </div>

--- a/src/resources/js/Components/DocumentSettingsForm.jsx
+++ b/src/resources/js/Components/DocumentSettingsForm.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import '../../css/DocumentSettingsForm.css';
 import { useDispatch, useSelector } from 'react-redux';
-import { showChecklistsOnDocument, hideChecklistsOnDocument } from '../store/checklistSlice';
+import { showChecklistsOnDocument, hideChecklistsOnDocument } from '../store/documentSettingsSlice';
 
 const DocumentSettingsForm = () => {
   const dispatch = useDispatch();
-  const showChecklists = useSelector((state) => state.checkLists.showingChecklistsOnDocument);
+  const showChecklists = useSelector((state) => state.documentSettings.showingChecklistsOnDocument);
 
   const handleCheckboxChange = (e) => {
     if (e.target.checked) {

--- a/src/resources/js/store/checklistSlice.js
+++ b/src/resources/js/store/checklistSlice.js
@@ -1,6 +1,11 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
+const initialState = {
+  showingChecklistsOnDocument: true,
+};
+
+
 export const fetchCheckLists = createAsyncThunk(
   'checkLists/fetchCheckLists',
   async (workflowId) => {
@@ -41,8 +46,15 @@ export const deleteChecklist = createAsyncThunk(
 
 const checkListSlice = createSlice({
   name: 'checkLists',
-  initialState: {},
-  reducers: {},
+  initialState,
+  reducers: {
+    showChecklistsOnDocument: (state) => {
+      state.showingChecklistsOnDocument = true;
+    },
+    hideChecklistsOnDocument: (state) => {
+      state.showingChecklistsOnDocument = false;
+    },
+  },
   extraReducers: (builder) => {
       builder
           .addCase(fetchCheckLists.fulfilled, (state, action) => {
@@ -76,6 +88,11 @@ const checkListSlice = createSlice({
           });
   },
 });
+
+export const {
+  showChecklistsOnDocument,
+  hideChecklistsOnDocument
+} = checkListSlice.actions;
 
 export const selectCheckListsByColumn = (state) => state.checkLists;
 export default checkListSlice.reducer;

--- a/src/resources/js/store/documentSettingsSlice.js
+++ b/src/resources/js/store/documentSettingsSlice.js
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  showingChecklistsOnDocument: true,
+};
+
+const documentSettingsSlice = createSlice({
+  name: 'documentSettings',
+  initialState,
+  reducers: {
+    showChecklistsOnDocument: (state) => {
+      state.showingChecklistsOnDocument = true;
+    },
+    hideChecklistsOnDocument: (state) => {
+      state.showingChecklistsOnDocument = false;
+    },
+  },
+});
+
+export const {
+  showChecklistsOnDocument,
+  hideChecklistsOnDocument
+} = documentSettingsSlice.actions;
+
+export default documentSettingsSlice.reducer;

--- a/src/resources/js/store/documentSettingsSlice.js
+++ b/src/resources/js/store/documentSettingsSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   showingChecklistsOnDocument: true,
+  showingFlowstepDescriptionsOnDocument: true,
 };
 
 const documentSettingsSlice = createSlice({
@@ -14,12 +15,20 @@ const documentSettingsSlice = createSlice({
     hideChecklistsOnDocument: (state) => {
       state.showingChecklistsOnDocument = false;
     },
+    showFlowstepDescriptionsOnDocument: (state) => {
+      state.showingFlowstepDescriptionsOnDocument = true;
+    },
+    hideFlowstepDescriptionsOnDocument: (state) => {
+      state.showingFlowstepDescriptionsOnDocument = false;
+    },
   },
 });
 
 export const {
   showChecklistsOnDocument,
-  hideChecklistsOnDocument
+  hideChecklistsOnDocument,
+  showFlowstepDescriptionsOnDocument,
+  hideFlowstepDescriptionsOnDocument,
 } = documentSettingsSlice.actions;
 
 export default documentSettingsSlice.reducer;

--- a/src/resources/js/store/modalSlice.js
+++ b/src/resources/js/store/modalSlice.js
@@ -1,10 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  isCheckListModalOpen: false,
-  isAddFlowstepModalOpen: false,
-  isUpdateFlowstepModalOpen: false,
-  isDocumentSettingsModalOpen: false,
+  showingChecklistsOnDocument: true,
 };
 
 const modalSlice = createSlice({

--- a/src/resources/js/store/store.js
+++ b/src/resources/js/store/store.js
@@ -5,6 +5,7 @@ import checklistsReducer from './checklistSlice';
 import workflowReducer from './workflowSlice';
 import modalReducer from './modalSlice';
 import selectedReducer from './selectedSlice';
+import documentSettingsReducer from './documentSettingsSlice';
 import memberReducerForGuest from './memberSliceForGuest';
 
 
@@ -16,6 +17,7 @@ const store = configureStore({
         workflow: workflowReducer,
         modal: modalReducer,
         selected: selectedReducer,
+        documentSettings: documentSettingsReducer,
         membersForGuest: memberReducerForGuest
     },
 });


### PR DESCRIPTION
## GitHub Issue Ticket
- none

## やった事
`このプルリクエストにて何をしたのか？`
 - Laravel
   - none
 - React
   - Documentコンポーネント上の表示制御を `documentSettingsSlice`で制御するように実装
   - flowstepsのdescriptionの表示切り替えを実装  

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Documentの表示項目を拡充した時に非表示項目を自由に選べるように実装

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
